### PR TITLE
Added catch so particles don't sink tracers to < 0

### DIFF
--- a/examples/subpolar.jl
+++ b/examples/subpolar.jl
@@ -123,7 +123,8 @@ h(k) = (k - 1) / Nz
 Σ(k) = (1 - exp(-stretching * h(k))) / (1 - exp(-stretching))
 ## Generating function
 z_faces(k) = Lz * (ζ₀(k) * Σ(k) - 1)
-grid = RectilinearGrid(size = (Nx, Ny, Nz), 
+grid = RectilinearGrid(
+                       size = (Nx, Ny, Nz), 
                        x = (0, Lx),
                        y = (0, Ly),
                        z = z_faces)
@@ -221,7 +222,7 @@ simulation.output_writers[:profiles] = NetCDFOutputWriter(model, fields, filenam
 run!(simulation)
 
 # Load and plot the results
-results = OceanBioME.Plot.load_tracers(simulation)
+results = OceanBioME.Plot.load_tracers("subpolar.nc", bgc.tracers, 1)
 OceanBioME.Plot.profiles(results)
 
 # Save the plot to a PDF file

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -2,10 +2,10 @@
     i, j = @index(Global, NTuple) 
     zpar=Oceananigans.Operators.znodes(par)
 
-    ∫chlᵉʳ = Oceananigans.Architectures.arch_array(grid.architecture, zeros(grid.Nz))#I've checked and this array conversion doesn't cost anything (on CPU at least)
+    ∫chlᵉʳ = arch_array(grid.architecture, zeros(grid.Nz))#I've checked and this array conversion doesn't cost anything (on CPU at least)
     @inbounds ∫chlᵉʳ[grid.Nz] = (chl[i, j, grid.Nz]/params.r_pig)^params.e_r*zpar[grid.Nz]
 
-    ∫chlᵉᵇ = Oceananigans.Architectures.arch_array(grid.architecture, zeros(grid.Nz))
+    ∫chlᵉᵇ = arch_array(grid.architecture, zeros(grid.Nz))
     @inbounds ∫chlᵉᵇ[grid.Nz] = (chl[i, j, grid.Nz]/params.r_pig)^params.e_b*zpar[grid.Nz]
 
     for k=grid.Nz-1:-1:1

--- a/src/Light/Light.jl
+++ b/src/Light/Light.jl
@@ -15,7 +15,7 @@ module Light
 using Oceananigans
 using KernelAbstractions
 using KernelAbstractions.Extras.LoopInfo: @unroll
-using Oceananigans.Architectures: device
+using Oceananigans.Architectures: device, arch_array
 
 include("2band.jl")
 

--- a/src/Models/Macroalgae/SLatissima.jl
+++ b/src/Models/Macroalgae/SLatissima.jl
@@ -15,6 +15,8 @@ module SLatissima
 using StructArrays, SugarKelp
 using OceanBioME: Particles
 using Oceananigans.Units: second,minute, minutes, hour, hours, day, days, year, years
+using Oceananigans.Architectures: arch_array
+using Oceananigans: CPU
 
 @inline f_curr(u, params) = params.uₐ*(1-exp(-u/params.u₀))+params.uᵦ
 
@@ -116,7 +118,7 @@ sink_fields = ((tracer=:NO₃, property=:j_NO₃, scalefactor=-1.0),
                     (tracer=:DOM, property=:e, scalefactor=1.0/6.56),#Rd_dom from LOBSTER
                     (tracer=:DD, property=:ν, scalefactor=1.0))
 
-function defineparticles(initials, n)
+function defineparticles(initials, n, arch=CPU())
     x̄₀ = []
     for var in [:x₀, :y₀, :z₀, :A₀, :N₀, :C₀]
         vals=getproperty(initials, var)
@@ -128,19 +130,19 @@ function defineparticles(initials, n)
             throw(ArgumentError("Invalid initial values given for $var, must be a single number or vector of length n"))
         end
     end
-    return StructArray{Particle}((x̄₀[1], x̄₀[2], x̄₀[3], zeros(n), zeros(n), zeros(n), x̄₀[4], x̄₀[5], x̄₀[6], [zeros(n) for i in 1:8]...))
+    return StructArray{Particle}((x̄₀[1], x̄₀[2], x̄₀[3], arch_array(arch, zeros(n)), arch_array(arch, zeros(n)), arch_array(arch, zeros(n)), x̄₀[4], x̄₀[5], x̄₀[6], [arch_array(arch, zeros(n)) for i in 1:8]...))
 end
 
 @inline no_dynamics(args...) = nothing
 
-function setup(n, x₀, y₀, z₀, A₀, N₀, C₀, latitude, density, T=nothing, S=nothing, urel=nothing, resp_model=2, paramset=defaults, custom_dynamics=no_dynamics, O₂=false)
+function setup(n, x₀, y₀, z₀, A₀, N₀, C₀, latitude, density, T=nothing, S=nothing, urel=nothing, resp_model=2, paramset=defaults, custom_dynamics=no_dynamics, O₂=false, arch=CPU())
     if (!isnothing(T) && !isnothing(S) && isnothing(urel))
         throw(ArgumentError("T and S functions with tracked velocity fields not currently implimented"))
     elseif ((isnothing(T) && !isnothing(S)) | (!isnothing(T) && isnothing(S)))
         throw(ArgumentError("T and S must both be functions or both be tracked fields"))
     end
 
-    particles = defineparticles((x₀=x₀, y₀=y₀, z₀=z₀, A₀=A₀, N₀=N₀, C₀=C₀), n)
+    particles = defineparticles((x₀=x₀, y₀=y₀, z₀=z₀, A₀=A₀, N₀=N₀, C₀=C₀), n, arch)
     property_dependencies = (:A, :N, :C, :NO₃, :NH₄, :PAR)
     λ_arr=SugarKelp.gen_λ(latitude)
     parameters = merge(paramset, (λ=λ_arr, resp_model=2))

--- a/src/Utils/Plot.jl
+++ b/src/Utils/Plot.jl
@@ -1,8 +1,9 @@
 module Plot
 using Plots, Oceananigans, JLD2, Statistics, NetCDF
 using Oceananigans.Units: second,minute, minutes, hour, hours, day, days, year, years
+using Oceananigans.Architectures: arch_array
 
-load_tracers(sim::Simulation, save_name=:profiles) = load_tracers(sim.output_writers[save_name].filepath)
+load_tracers(sim::Simulation; save_name=:profiles, tracers=(:NO₃, :NH₄, :P, :Z, :D, :DD), tstart=1) = load_tracers(sim.output_writers[save_name].filepath, tracers=tracers, tstart=tstart)
 
 mutable struct model_results{T, X, Y, Z, t, R}
     tracers :: T
@@ -25,7 +26,7 @@ struct NetCDFResults
     tstart
 end
 
-function load_tracers(path::String, tracers=(:NO₃, :NH₄, :P, :Z, :D, :DD), tstart=0)
+function load_tracers(path::String; tracers=(:NO₃, :NH₄, :P, :Z, :D, :DD), tstart=1)
     if path[end-4:end] == ".jld2"
         file_profiles = jldopen(path)
     elseif path[end-2:end] == ".nc"


### PR DESCRIPTION
I came across an issue that with kelp in the model tracers can go negative, then the PAR calculation fails because it has negative number ^ fraction. I think this is because the kelp is in too high a density and multiple particles are drawing from the same points so it can pull the concentration of a tracer below zero. If NH4 goes negative first then on the next step L_NO3 would become very large from exp(-NH4), this would very quickly make NO3 become negative so L_NO3 would be large and negative. The P term in S(P) would then be large and negative making P go negative, which then causes the error when the PAR is calculated.

I've fixed this by changing the sinking function to sink to min(X-dX*dt, 0) which does mean that the particle gets to take up a tiny amount more than is actually available to it but it prevents the error. I'm not sure this is the best solution but hopefully its okay since it would only occur for one time step when multiple particles are sinking from the same grid point (I think), and I will make it throw a warning so we can see if it is happening often.

I think the only way to fix this properly would be to make the particle calculations happen serially (they are currently dispatched in parallel using the KernalAbstraction stuff like Oceananigans uses).

Do you think that this is an okay solution @johnryantaylor?