### PR TITLE
Make tests run on all file changes (not just `src` etc.)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,19 +3,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'src/*'
-      - 'test/*'
-      - '.github/workflows/*'
-      - 'Project.toml'
   pull_request:
     branches: 
       - main
-    paths:
-      - 'src/*'
-      - 'test/*'
-      - '.github/workflows/*'
-      - 'Project.toml'
 
 env:
   DATADEPS_ALWAYS_ACCEPT: true


### PR DESCRIPTION
When repo was private we did this to save action minutes but they're unlimitted on public repos