### PR TITLE
Fix docs stable badge url + add docs dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![](OceanBioME_headerbar.jpg?raw=true)
-[![Documentaiton](https://img.shields.io/badge/documentation-stable%20release-blue?style=flat-square)](https://oceanbiome.github.io/OceanBioME.jl/dev/)
+[![Documentation](https://img.shields.io/badge/documentation-stable%20release-blue?style=flat-square)](https://oceanbiome.github.io/OceanBioME.jl/stable/)
+[![Documentation](https://img.shields.io/badge/documentation-dev%20release-orange?style=flat-square)](https://oceanbiome.github.io/OceanBioME.jl/dev/)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://mit-license.org)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![Ask us anything: discussion](https://img.shields.io/badge/Ask%20us-anything-1abc9c.svg?style=flat-square)](https://github.com/OceanBioME/OceanBioME.jl/discussions)


### PR DESCRIPTION
The docs stable badge was pointing to the dev docs. This PR fixes this and adds a "docs dev" badge. Feel free to drop the "docs dev" badge if not needed.