### PR TITLE
added advection back to examples

### DIFF
--- a/examples/column.jl
+++ b/examples/column.jl
@@ -49,8 +49,7 @@ model = NonhydrostaticModel(; grid,
                               biogeochemistry = LOBSTER(; grid,
                                                           surface_phytosynthetically_active_radiation = PAR⁰,
                                                           carbonates = true),
-                              boundary_conditions = (DIC = FieldBoundaryConditions(top = CO₂_flux), ),
-                              advection = nothing)
+                              boundary_conditions = (DIC = FieldBoundaryConditions(top = CO₂_flux), ))
 
 set!(model, P = 0.03, Z = 0.03, NO₃ = 4.0, NH₄ = 0.05, DIC = 2239.8, Alk = 2409.0)
 

--- a/examples/data_forced.jl
+++ b/examples/data_forced.jl
@@ -71,8 +71,7 @@ model = NonhydrostaticModel(; grid,
                               biogeochemistry = LOBSTER(; grid,
                                                           surface_phytosynthetically_active_radiation = surface_PAR,
                                                           carbonates = true),
-                              boundary_conditions = (DIC = FieldBoundaryConditions(top = CO₂_flux),),
-                              advection = nothing)
+                              boundary_conditions = (DIC = FieldBoundaryConditions(top = CO₂_flux),))
 
 set!(model, P = 0.03, Z = 0.03, NO₃ = 11.0, NH₄ = 0.05, DIC = 2200.0, Alk = 2400.0)
 

--- a/examples/kelp.jl
+++ b/examples/kelp.jl
@@ -72,8 +72,7 @@ biogeochemistry = LOBSTER(; grid,
 
 model = NonhydrostaticModel(; grid,
                               closure = ScalarDiffusivity(ν = κₜ, κ = κₜ), 
-                              biogeochemistry,
-                              advection = nothing)
+                              biogeochemistry)
 
 set!(model, P = 0.03, Z = 0.03, NO₃ = 4.0, NH₄ = 0.05, DIC = 2239.8, Alk = 2409.0)
 


### PR DESCRIPTION
Before the advection fix in Oceananigans you could turn off advection (i.e. set it to `nothing`) in column models because the drift velocities had their own advection schemes and it sped up run time. Now that all velocities are treated together we can't do this anymore so need an advection scheme to be on for particle sinking to work correctly.

(@syou83syou83 you may need to update this in your scripts if you update your OceanBioME version)