### PR TITLE
Generalize  `TwoBandPhotosyntheticallyActiveRadiation` kernel to allow curvilinear grids

### DIFF
--- a/src/Boundaries/Sediments/Sediments.jl
+++ b/src/Boundaries/Sediments/Sediments.jl
@@ -11,7 +11,6 @@ using Oceananigans.Advection: div_Uc
 using Oceananigans.Units: day
 using Oceananigans.Fields: CenterField, Face
 using Oceananigans.Biogeochemistry: biogeochemical_drift_velocity
-using Oceananigans.Grids: znode
 
 import Oceananigans.Biogeochemistry: update_tendencies!
 import Adapt: adapt_structure, adapt

--- a/src/Boundaries/Sediments/simple_multi_G.jl
+++ b/src/Boundaries/Sediments/simple_multi_G.jl
@@ -90,7 +90,7 @@ function SimpleMultiG(grid;
                                            D = -1.3349, 
                                            E = 0.1826, 
                                            F = - 0.0143),
-                      depth = abs(znode(1, grid, Face())),
+                      depth = abs(znodes(grid, Face())[1]),
                       solid_dep_params::P4 = (A = 0.233, 
                                               B = 0.336, 
                                               C = 982, 

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,8 +1,8 @@
 @kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, P, surface_PAR, t, PAR_model) 
     i, j = @index(Global, NTuple)
 
-    x = xnode(i, j, 1, grid, Center(), Center(), Center())
-    y = ynode(i, j, 1, grid, Center(), Center(), Center())
+    x = node(i, j, 1, grid, Center(), Center(), Center())
+    y = node(i, j, 1, grid, Center(), Center(), Center())
     
     PAR⁰ = surface_PAR(x, y, t)
 
@@ -89,7 +89,9 @@ Keyword Arguments
 
 - `grid`: grid for building the model on
 - `water_red_attenuation`, ..., `phytoplankton_chlorophyll_ratio`: parameter values
-- `surface_PAR`: function (or array in the future) for the photosynthetically available radiation at the surface, should be shape `f(x, y, t)`
+- `surface_PAR`: function (or array in the future) for the photosynthetically available radiation at the surface, 
+   which should be `f(x, y, t)` where `x` and `y` are the native coordinates (i.e. meters for rectilinear grids
+   and latitude/longitude as appropriate)
 """
 function TwoBandPhotosyntheticallyActiveRadiation(; grid, 
                                                     water_red_attenuation::FT = 0.225, # 1/m

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,7 +1,8 @@
 @kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, P, surface_PAR, t, PAR_model) 
     i, j = @index(Global, NTuple)
 
-    x, y = @inbounds xnodes(grid, Center(), Center(), Center())[i], ynodes(grid, Center(), Center(), Center())[j]
+    x = xnode(i, j, 1, grid, Center(), Center(), Center())
+    y = ynode(i, j, 1, grid, Center(), Center(), Center())
     
     PAR⁰ = surface_PAR(x, y, t)
 

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,8 +1,7 @@
 @kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, P, surface_PAR, t, PAR_model) 
     i, j = @index(Global, NTuple)
 
-    x = node(i, j, 1, grid, Center(), Center(), Center())
-    y = node(i, j, 1, grid, Center(), Center(), Center())
+    x, y, _ = node(i, j, 1, grid, Center(), Center(), Center())
     
     PAR⁰ = surface_PAR(x, y, t)
 

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,7 +1,7 @@
 @kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, P, surface_PAR, t, PAR_model) 
     i, j = @index(Global, NTuple)
 
-    x, y = @inbounds xnodes(grid, Center(), Center(), Center())[i], ynodes(j, grid, Center(), Center(), Center())[j]
+    x, y = @inbounds xnodes(grid, Center(), Center(), Center())[i], ynodes(grid, Center(), Center(), Center())[j]
     
     PAR⁰ = surface_PAR(x, y, t)
 

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,7 +1,7 @@
 @kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, P, surface_PAR, t, PAR_model) 
     i, j = @index(Global, NTuple)
 
-    x, y = xnode(i, grid, Center()), ynode(j, grid, Center())
+    x, y = @inbounds xnodes(grid, Center(), Center(), Center())[i], ynodes(j, grid, Center(), Center(), Center())[j]
     
     PAR⁰ = surface_PAR(x, y, t)
 
@@ -14,8 +14,8 @@
     r  = PAR_model.pigment_ratio
     Rᶜₚ = PAR_model.phytoplankton_chlorophyll_ratio
 
-    zᶜ = znodes(grid, Center())
-    zᶠ = znodes(grid, Face())
+    zᶜ = znodes(grid, Center(), Center(), Center())
+    zᶠ = znodes(grid, Center(), Center(), Face())
 
     # first point below surface
     @inbounds begin

--- a/src/Light/Light.jl
+++ b/src/Light/Light.jl
@@ -10,7 +10,7 @@ using KernelAbstractions.Extras.LoopInfo: @unroll
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Utils: launch!
 using Oceananigans: Center, Face, fields
-using Oceananigans.Grids: xnodes, ynodes, znodes
+using Oceananigans.Grids: xnode, ynode, znodes
 using Oceananigans.Fields: CenterField, TracerFields
 using Oceananigans.BoundaryConditions: fill_halo_regions!, 
                                        ValueBoundaryCondition, 

--- a/src/Light/Light.jl
+++ b/src/Light/Light.jl
@@ -10,7 +10,7 @@ using KernelAbstractions.Extras.LoopInfo: @unroll
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Utils: launch!
 using Oceananigans: Center, Face, fields
-using Oceananigans.Grids: xnode, ynode, znodes
+using Oceananigans.Grids: node, znodes
 using Oceananigans.Fields: CenterField, TracerFields
 using Oceananigans.BoundaryConditions: fill_halo_regions!, 
                                        ValueBoundaryCondition, 

--- a/src/Light/Light.jl
+++ b/src/Light/Light.jl
@@ -10,7 +10,7 @@ using KernelAbstractions.Extras.LoopInfo: @unroll
 using Oceananigans.Architectures: device, architecture
 using Oceananigans.Utils: launch!
 using Oceananigans: Center, Face, fields
-using Oceananigans.Grids: xnode, ynode, znodes
+using Oceananigans.Grids: xnodes, ynodes, znodes
 using Oceananigans.Fields: CenterField, TracerFields
 using Oceananigans.BoundaryConditions: fill_halo_regions!, 
                                        ValueBoundaryCondition, 

--- a/src/Models/Individuals/SLatissima.jl
+++ b/src/Models/Individuals/SLatissima.jl
@@ -199,11 +199,6 @@ Base.@kwdef struct SLatissima{AR, FT, U, T, S, P, F} <: BiogeochemicalParticles
     latitude :: FT = 57.5
 end
 
-# for some reason this doesn't get called, 
-# but if you manually call `adapt_structure(CuArray, particles::SLatissima)` 
-# it returns a GPU friendly version. To automagically overcome this I'm `arch_array`ing 
-# above but that does necessitate passing the grid to the particles
-# weird thing is this is definitly getting called a some point, but not with the correct `to`.
 adapt_structure(to, kelp::SLatissima) = SLatissima(kelp.architecture,
                                                    kelp.growth_rate_adjustement, 
                                                    kelp.photosynthetic_efficiency,
@@ -286,10 +281,6 @@ end
 
     bgc_tracers = required_biogeochemical_tracers(bgc)
 
-    #nodes, weights, normfactor = @inbounds get_nearest_nodes(x, y, z, grid, (Center(), Center(), Center()))
-
-    #@unroll for (n, weight) in enumerate(weights)
-        # Reflect back on Bounded boundaries or wrap around for Periodic boundaries
     i, j, k = fractional_indices(x, y, z, (Center(), Center(), Center()), grid)
 
     # Convert fractional indices to unit cell coordinates 0 ≤ (ξ, η, ζ) ≤ 1

--- a/src/Models/Individuals/SLatissima.jl
+++ b/src/Models/Individuals/SLatissima.jl
@@ -292,13 +292,15 @@ end
         # Reflect back on Bounded boundaries or wrap around for Periodic boundaries
     i, j, k = fractional_indices(x, y, z, (Center(), Center(), Center()), grid)
 
-    # Convert fractional indices to unit cell coordinates 0 <= (ξ, η, ζ) <=1
+    # Convert fractional indices to unit cell coordinates 0 ≤ (ξ, η, ζ) ≤ 1
     # and integer indices (with 0-based indexing).
     ξ, i = modf(i)
     η, j = modf(j)
     ζ, k = modf(k)
 
-    i, j, k = (get_node(TX(), Int(ifelse(ξ < 0.5, i + 1, i + 2)), grid.Nx), get_node(TY(), Int(ifelse(η < 0.5, j + 1, j + 2)), grid.Ny), get_node(TZ(), Int(ifelse(ζ < 0.5, k + 1, k + 2)), grid.Nz))
+    i, j, k = (get_node(TX(), Int(ifelse(ξ < 0.5, i + 1, i + 2)), grid.Nx),
+               get_node(TY(), Int(ifelse(η < 0.5, j + 1, j + 2)), grid.Ny),
+               get_node(TZ(), Int(ifelse(ζ < 0.5, k + 1, k + 2)), grid.Nz))
 
     node_volume = volume(i, j, k, grid, Center(), Center(), Center())
 

--- a/src/Particles/tracer_tendencies.jl
+++ b/src/Particles/tracer_tendencies.jl
@@ -1,4 +1,4 @@
 using Oceananigans.Grids: AbstractGrid, Bounded, Periodic
 
-@inline get_node(::Bounded, i, N) = min(max(i, 1), N)
-@inline get_node(::Periodic, i, N) = ifelse(i < 1, N , ifelse(i > N, 1, i))
+@inline get_node(::Bounded,  i, N) = min(max(i, 1), N)
+@inline get_node(::Periodic, i, N) = ifelse(i < 1, N, ifelse(i > N, 1, i))

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -1,22 +1,24 @@
 using Oceananigans, Test
-using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation, LOBSTER
-using Oceananigans.Biogeochemistry: update_biogeochemical_state!
+using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation, LOBSTER, NutrientPhytoplanktonZooplanktonDetritus
+using Oceananigans.Biogeochemistry: update_biogeochemical_state!, required_biogeochemical_tracers
 
-grid = RectilinearGrid(size=(1,1,2), extent=(1,1,2))
+Pᵢ(x,y,z) = 2.5 + z
 
-@testset "Two band attenuation" begin
+function test_two_band(grid, bgc, model_type)
+    biogeochemistry = bgc(; grid,
+                            light_attenuation_model = TwoBandPhotosyntheticallyActiveRadiation(; grid),
+                            surface_phytosynthetically_active_radiation = (x, y, t) -> 100.0)
 
-    model = NonhydrostaticModel(; grid, 
-                                  biogeochemistry = LOBSTER(; grid,
-                                                              light_attenuation_model = TwoBandPhotosyntheticallyActiveRadiation(; grid),
-                                                              surface_phytosynthetically_active_radiation = (x, y, t) -> 100.0))
-    Pᵢ(x,y,z) = 2.5 + z
+    model = model_type(; grid, 
+                         biogeochemistry,
+                         tracers = unique((required_biogeochemical_tracers(biogeochemistry)..., :T, :S))) # because hydrostatic free surface will request T and S and some BGC models will too
 
     set!(model, P = Pᵢ)
 
     update_biogeochemical_state!(model.biogeochemistry, model)
 
     PAR_model = model.biogeochemistry.light_attenuation_model
+
     kʳ = PAR_model.water_red_attenuation
     kᵇ = PAR_model.water_blue_attenuation
     χʳ = PAR_model.chlorophyll_red_attenuation
@@ -38,5 +40,22 @@ grid = RectilinearGrid(size=(1,1,2), extent=(1,1,2))
 
     results_PAR = convert(Array, model.biogeochemistry.light_attenuation_model.field)[1, 1, 1:2]
 
-    @test all(results_PAR .≈ reverse(expected_PAR))
+    return all(results_PAR .≈ reverse(expected_PAR))
 end
+
+archs = (CPU(), )
+
+@testset "Light attenuaiton model" begin 
+    for model in (NonhydrostaticModel, HydrostaticFreeSurfaceModel),
+        arch in archs,
+        grid in (RectilinearGrid(arch; size = (2, 2, 2), extent = (2, 2, 2)), 
+                 LatitudeLongitudeGrid(arch; size = (5, 5, 2), longitude = (-180, 180), latitude = (-85, 85), z = (-2, 0))),
+        bgc in (LOBSTER, NutrientPhytoplanktonZooplanktonDetritus)
+
+        if !((model == NonhydrostaticModel) && ((grid isa LatitudeLongitudeGrid) | (grid isa OrthogonalSphericalShellGrid)))
+            @info "Testing $bgc in $model on $grid..."
+            @test test_two_band(grid, bgc, model)
+        end
+    end
+end
+             


### PR DESCRIPTION
Not sure this is the most efficient way todo this, but since `xnode` is defiend differedntly for different grid types this is by far the easiest fix. The alternative would be to define `xnode(i, grid, lx, ly, lz)` for RectilinearGrids. Perhaps that solution would be better.

Closes #119 