### PR TITLE
Added passing of time to sediment tendency calculation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OceanBioME"
 uuid = "a49af516-9db8-4be4-be45-1dad61c5a376"
 authors = ["Jago Strong-Wright <js2430@damtp.cam.ac.uk> and contributors"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Boundaries/Sediments/Sediments.jl
+++ b/src/Boundaries/Sediments/Sediments.jl
@@ -52,8 +52,6 @@ end
     i, j = @index(Global, NTuple)
 
     _calculate_sediment_tendencies!(i, j, sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time)
-
-    return nothing
 end
 
 

--- a/src/Boundaries/Sediments/Sediments.jl
+++ b/src/Boundaries/Sediments/Sediments.jl
@@ -17,7 +17,6 @@ using Oceananigans.Grids: zspacing
 using Oceananigans.Operators: volume
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, immersed_cell
 
-
 import Adapt: adapt_structure, adapt
 import Oceananigans.Biogeochemistry: update_tendencies!
 
@@ -38,7 +37,7 @@ function update_tendencies!(bgc, sediment::FlatSediment, model)
     biogeochemistry = bgc.underlying_biogeochemistry
 
     launch!(arch, model.grid, :xy,
-            _calculate_tendencies!,
+            calculate_sediment_tendencies!,
             sediment, biogeochemistry, model.grid, 
             sinking_advection(biogeochemistry, model.advection), 
             required_tracers(sediment, biogeochemistry, model.tracers), 
@@ -48,6 +47,9 @@ function update_tendencies!(bgc, sediment::FlatSediment, model)
             
     return nothing
 end
+
+@kernel calculate_sediment_tendencies!(sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time) = 
+    _calculate_sediment_tendencies!(@index(Global, NTuple)..., sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time)
 
 
 @kernel function store_flat_tendencies!(G⁻, G⁰)

--- a/src/Boundaries/Sediments/Sediments.jl
+++ b/src/Boundaries/Sediments/Sediments.jl
@@ -43,7 +43,8 @@ function update_tendencies!(bgc, sediment::FlatSediment, model)
             sinking_advection(biogeochemistry, model.advection), 
             required_tracers(sediment, biogeochemistry, model.tracers), 
             required_tendencies(sediment, biogeochemistry, model.timestepper.Gⁿ), 
-            sediment.tendencies.Gⁿ)
+            sediment.tendencies.Gⁿ,
+            model.clock.time)
             
     return nothing
 end

--- a/src/Boundaries/Sediments/Sediments.jl
+++ b/src/Boundaries/Sediments/Sediments.jl
@@ -48,8 +48,13 @@ function update_tendencies!(bgc, sediment::FlatSediment, model)
     return nothing
 end
 
-@kernel calculate_sediment_tendencies!(sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time) = 
-    _calculate_sediment_tendencies!(@index(Global, NTuple)..., sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time)
+@kernel function calculate_sediment_tendencies!(sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time)
+    i, j = @index(Global, NTuple)
+
+    _calculate_sediment_tendencies!(i, j, sediment, biogeochemistry, grid, advection, tracers, tendencies, sediment_tendencies, time)
+
+    return nothing
+end
 
 
 @kernel function store_flat_tendencies!(G⁻, G⁰)

--- a/src/Boundaries/Sediments/instant_remineralization.jl
+++ b/src/Boundaries/Sediments/instant_remineralization.jl
@@ -89,9 +89,7 @@ sediment_fields(model::InstantRemineralisation) = (N_storage = model.fields.N_st
 
 @inline bottom_index_array(sediment::InstantRemineralisation) = sediment.bottom_indices
 
-@kernel function _calculate_tendencies!(sediment::InstantRemineralisation, bgc, grid, advection, tracers, tendencies, sediment_tendencies, time)
-    i, j = @index(Global, NTuple)
-
+function _calculate_sediment_tendencies!(i, j, sediment::InstantRemineralisation, bgc, grid, advection, tracers, tendencies, sediment_tendencies, time)
     k = bottom_index(i, j, sediment)
 
     Δz = zspacing(i, j, k, grid, Center(), Center(), Center())

--- a/src/Boundaries/Sediments/instant_remineralization.jl
+++ b/src/Boundaries/Sediments/instant_remineralization.jl
@@ -89,7 +89,7 @@ sediment_fields(model::InstantRemineralisation) = (N_storage = model.fields.N_st
 
 @inline bottom_index_array(sediment::InstantRemineralisation) = sediment.bottom_indices
 
-@kernel function _calculate_tendencies!(sediment::InstantRemineralisation, bgc, grid, advection, tracers, tendencies, sediment_tendencies)
+@kernel function _calculate_tendencies!(sediment::InstantRemineralisation, bgc, grid, advection, tracers, tendencies, sediment_tendencies, time)
     i, j = @index(Global, NTuple)
 
     k = bottom_index(i, j, sediment)

--- a/src/Boundaries/Sediments/simple_multi_G.jl
+++ b/src/Boundaries/Sediments/simple_multi_G.jl
@@ -154,9 +154,7 @@ sediment_fields(model::SimpleMultiG) = (C_slow = model.fields.C_slow,
 
 @inline bottom_index_array(sediment::SimpleMultiG) = sediment.bottom_indices
 
-@kernel function _calculate_tendencies!(sediment::SimpleMultiG, bgc, grid, advection, tracers, tendencies, sediment_tendencies, t)
-    i, j = @index(Global, NTuple)
-
+function _calculate_sediment_tendencies!(i, j, sediment::SimpleMultiG, bgc, grid, advection, tracers, tendencies, sediment_tendencies, t)
     k = bottom_index(i, j, sediment)
     depth = @inbounds -znodes(grid, Center(), Center(), Center())[k]
 

--- a/src/Boundaries/Sediments/simple_multi_G.jl
+++ b/src/Boundaries/Sediments/simple_multi_G.jl
@@ -154,7 +154,7 @@ sediment_fields(model::SimpleMultiG) = (C_slow = model.fields.C_slow,
 
 @inline bottom_index_array(sediment::SimpleMultiG) = sediment.bottom_indices
 
-@kernel function _calculate_tendencies!(sediment::SimpleMultiG, bgc, grid, advection, tracers, tendencies, sediment_tendencies)
+@kernel function _calculate_tendencies!(sediment::SimpleMultiG, bgc, grid, advection, tracers, tendencies, sediment_tendencies, t)
     i, j = @index(Global, NTuple)
 
     k = bottom_index(i, j, sediment)


### PR DESCRIPTION
I've come across an instance where I'm trying to write a different sediment model and need the forcings to have a time dependence so need to pass the time to `_calculate_tendencies!`, and modifies sediment tendency kernel to make new method definition possible.