### PR TITLE
Update convenience constructor (`NutrientPhytoplanktonZooplanktonDetritus` and `LOBSTER`) docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OceanBioME"
 uuid = "a49af516-9db8-4be4-be45-1dad61c5a376"
 authors = ["Jago Strong-Wright <js2430@damtp.cam.ac.uk> and contributors"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Models/AdvectedPopulations/LOBSTER/LOBSTER.jl
+++ b/src/Models/AdvectedPopulations/LOBSTER/LOBSTER.jl
@@ -189,7 +189,7 @@ end
               large_detritus_remineralisation_rate::FT = 5.88e-7, # 1/s
               phytoplankton_exudation_fraction::FT = 0.05,
               nitrification_rate::FT = 5.8e-7, # 1/s
-              ammonia_fraction_of_exudate::FT = 0.75,
+              ammonia_fraction_of_exudate::FT = 0.75, 
               ammonia_fraction_of_excriment::FT = 0.5,
               ammonia_fraction_of_detritus::FT = 0.0,
               phytoplankton_redfield::FT = 6.56, # mol C/mol N
@@ -198,26 +198,29 @@ end
               organic_carbon_calcate_ratio::FT = 0.1, # mol CaCO₃/mol C
               respiration_oxygen_nitrogen_ratio::FT = 10.75, # mol O/molN
               nitrification_oxygen_nitrogen_ratio::FT = 2.0, # mol O/molN
-              slow_sinking_mortality_fraction::FT = 0.5,
+              slow_sinking_mortality_fraction::FT = 0.5, 
               fast_sinking_mortality_fraction::FT = 0.5,
               dissolved_organic_breakdown_rate::FT = 3.86e-7, # 1/s
               zooplankton_calcite_dissolution::FT = 0.3,
 
-              surface_photosynthetically_active_radiation::SPAR = default_surface_PAR,
+              surface_photosynthetically_active_radiation = default_surface_PAR,
 
               light_attenuation_model::LA =
-                  TwoBandPhotosyntheticallyActiveRadiation(; grid,
+                  TwoBandPhotosyntheticallyActiveRadiation(; grid, 
                                                              surface_PAR = surface_photosynthetically_active_radiation),
               sediment_model::S = nothing,
 
               carbonates::Bool = false,
               oxygen::Bool = false,
-              variable_redfield = false,
+              variable_redfield::Bool = false,
 
-              sinking_speed = (sPOM = 3.47e-5, bPOM = 200/day),
+              sinking_speeds = (sPOM = 3.47e-5, bPOM = 200/day),
               open_bottom::Bool = true,
 
-              particles::P = nothing)
+              scale_negatives = false,
+
+              particles::P = nothing,
+              modifiers::M = nothing)
 
 Construct an instance of the [LOBSTER](@ref LOBSTER) biogeochemical model.
 
@@ -232,7 +235,9 @@ Keyword Arguments
 - `carbonates`, `oxygen`, and `variable_redfield`: include models for carbonate chemistry and/or oxygen chemistry and/or variable redfield ratio dissolved and particulate organic matter
 - `sinking_speed`: named tuple of constant sinking, of fields (i.e. `ZFaceField(...)`) for any tracers which sink (convention is that a sinking speed is positive, but a field will need to follow the usual down being negative)
 - `open_bottom`: should the sinking velocity be smoothly brought to zero at the bottom to prevent the tracers leaving the domain
+- `scale_negatives`: scale negative tracers?
 - `particles`: slot for `BiogeochemicalParticles`
+- `modifiers`: slot for components which modify the biogeochemistry when the tendencies have been calculated or when the state is updated
 
 Example
 =======

--- a/src/Models/AdvectedPopulations/NPZD.jl
+++ b/src/Models/AdvectedPopulations/NPZD.jl
@@ -103,7 +103,7 @@ end
                                                phyto_base_mortality_rate::FT = 0.0101 / day, # 1/s/(mmol N / m³)
                                                maximum_grazing_rate::FT = 2.1522 / day, # 1/s
                                                grazing_half_saturation::FT = 0.5573, # mmol N/m³
-                                               assimulation_efficiency::FT = 0.9116,
+                                               assimulation_efficiency::FT = 0.9116, 
                                                base_excretion_rate::FT = 0.0102 / day, # 1/s/(mmol N / m³)
                                                zoo_base_mortality_rate::FT = 0.3395 / day, # 1/s/(mmol N / m³)²
                                                remineralization_rate::FT = 0.1213 / day, # 1/s
@@ -113,11 +113,14 @@ end
                                                    TwoBandPhotosyntheticallyActiveRadiation(; grid,
                                                                                               surface_PAR = surface_photosynthetically_active_radiation),
                                                sediment_model::S = nothing,
-
+                
                                                sinking_speeds = (P = 0.2551/day, D = 2.7489/day),
                                                open_bottom::Bool = true,
 
-                                               particles::P = nothing)
+                                               scale_negatives = false,
+                                                                                      
+                                               particles::P = nothing,
+                                               modifiers::M = nothing)
 
 Construct a Nutrient-Phytoplankton-Zooplankton-Detritus ([NPZD](@ref NPZD)) biogeochemical model.
 
@@ -131,7 +134,9 @@ Keyword Arguments
 - `sediment_model`: slot for `AbstractSediment`
 - `sinking_speed`: named tuple of constant sinking, of fields (i.e. `ZFaceField(...)`) for any tracers which sink (convention is that a sinking speed is positive, but a field will need to follow the usual down being negative)
 - `open_bottom`: should the sinking velocity be smoothly brought to zero at the bottom to prevent the tracers leaving the domain
+- `scale_negatives`: scale negative tracers?
 - `particles`: slot for `BiogeochemicalParticles`
+- `modifiers`: slot for components which modify the biogeochemistry when the tendencies have been calculated or when the state is updated
 
 Example
 =======


### PR DESCRIPTION
Realised they don't include info about how to use `scale_negatives` etc.

Also fixes #151