### PR TITLE
abstract out biogeochemical particles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OceanBioME"
 uuid = "a49af516-9db8-4be4-be45-1dad61c5a376"
 authors = ["Jago Strong-Wright <js2430@damtp.cam.ac.uk> and contributors"]
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Particles/Particles.jl
+++ b/src/Particles/Particles.jl
@@ -20,7 +20,9 @@ import Oceananigans.OutputWriters: fetch_output
 import Base: length, size, show, summary
 import Adapt: adapt_structure
 
-struct BiogeochemicalParticles{N, B, A, F, T, I, S, X, Y, Z}
+abstract type AbstractBiogeochemicalParticles end
+
+struct BiogeochemicalParticles{N, B, A, F, T, I, S, X, Y, Z} <: AbstractBiogeochemicalParticles
       biogeochemistry :: B
             advection :: A
                fields :: F 
@@ -119,8 +121,8 @@ Adapt.adapt_structure(to, p::BiogeochemicalParticles{N}) where N =
                                adapt(to, p.z))
 
 # Type piracy...oops
-const BGC_WITH_PARTICLES = Union{<:DiscreteBiogeochemistry{<:Any, <:Any, <:Any, <:BiogeochemicalParticles},
-                                 <:ContinuousBiogeochemistry{<:Any, <:Any, <:Any, <:BiogeochemicalParticles}}
+const BGC_WITH_PARTICLES = Union{<:DiscreteBiogeochemistry{<:Any, <:Any, <:Any, <:AbstractBiogeochemicalParticles},
+                                 <:ContinuousBiogeochemistry{<:Any, <:Any, <:Any, <:AbstractBiogeochemicalParticles}}
 
 const MODEL_WITH_BGC_PARTICLES = 
     Union{<:NonhydrostaticModel{<:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:Any, <:BGC_WITH_PARTICLES},


### PR DESCRIPTION
This allows a particle model to bypass all of the stuff which makes simple particle models easy to setup, and I need it for this model: https://github.com/jagoosw/GiantKelpDynamics/pull/7

Maybe BiogeochemicalParticles should be renamed ContinuousBiogeochemicalParticles