### PR TITLE
Add buffer variables for the Biogeochemical Particles

### DIFF
--- a/src/Models/Individuals/SugarKelp/SugarKelp.jl
+++ b/src/Models/Individuals/SugarKelp/SugarKelp.jl
@@ -25,7 +25,7 @@ using Oceananigans.Units
 using OceanBioME: NewtonRaphsonSolver
 using OceanBioME.Particles: BiogeochemicalParticles
 
-import OceanBioME.Particles: required_particle_fields, required_tracers, coupled_tracers
+import OceanBioME.Particles: required_particle_fields, required_tracers, coupled_tracers, buffer_variables
 
 """
     SugarKelp
@@ -172,8 +172,11 @@ SugarKelpParticles(n; grid::AbstractGrid{FT}, kelp_parameters = NamedTuple(), kw
 # @inline coupled_tracers(::SugarKelp) = (NO₃ = :NO₃, NH₄ = :NH₄, DON = :DOM, bPON = :POM)
 # if you have a simpler model ... there must be a better way todo this
 
+@inline buffer_variables(::SugarKelp) = (:Photosynthesis,)
+
 include("equations.jl")
 include("coupling.jl")
+include("buffer.jl")
 include("show.jl")
 
 end # module

--- a/src/Models/Individuals/SugarKelp/buffer.jl
+++ b/src/Models/Individuals/SugarKelp/buffer.jl
@@ -1,0 +1,4 @@
+import OceanBioME.Particles: compute_buffer_variable
+
+compute_buffer_variable(::Val{:Photosynthesis}, kelp::SugarKelp, u, v, w, T, NO₃, NH₄, PAR) =
+    photosynthesis(kelp, T, PAR)

--- a/src/Models/Individuals/SugarKelp/coupling.jl
+++ b/src/Models/Individuals/SugarKelp/coupling.jl
@@ -1,43 +1,41 @@
 #:NO₃, :NH₄, :DIC, :O₂, :DOC, :DON, :bPOC, :bPON
 
-@inline function (kelp::SugarKelp)(::Val{:NO₃}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
+@inline function (kelp::SugarKelp)(::Val{:NO₃}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
     J = nitrate_uptake(kelp, N, NO₃, u, v, w)
 
     return -J * A / (day * 14 * 0.001) # gN/dm^2/hr to mmol N/s
 end
 
-@inline function (kelp::SugarKelp)(::Val{:NH₄}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
+@inline function (kelp::SugarKelp)(::Val{:NH₄}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
     J = ammonia_uptake(kelp, t, A, N, C, T, NH₄, u, v, w)
     
     return -J * A / (day * 14 * 0.001) # gN/dm^2/hr to mmol N/s
 end
 
-@inline function (kelp::SugarKelp)(::Val{:DIC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
-    P = photosynthesis(kelp, T, PAR)
+@inline function (kelp::SugarKelp)(::Val{:DIC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
 
     μ = growth(kelp, t, A, N, C, T, NH₄, u, v, w)
 
     R = respiration(kelp, t, A, N, C, T, NO₃, NH₄, u, v, w, μ)
     
-    return -(P - R) * A / (day * 12 * 0.001)  # gC/dm^2/hr to mmol C/s
+    return -(photosynthesis_var - R) * A / (day * 12 * 0.001)  # gC/dm^2/hr to mmol C/s
 end 
 
 # I now know that this may not be correct..., it probably should vary by where the nitrogen comes from
-@inline (kelp::SugarKelp)(::Val{:O₂}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR) =
-    - kelp(Val(:DIC), t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
+@inline (kelp::SugarKelp)(::Val{:O₂}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var) =
+    - kelp(Val(:DIC), t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
 
-@inline function (kelp::SugarKelp)(::Val{:DOC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
-    P = photosynthesis(kelp, T, PAR)
+@inline function (kelp::SugarKelp)(::Val{:DOC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
 
     e = specific_carbon_exudate(kelp, C)
     
-    return e * P * A / (day * 12 * 0.001)  # gC/dm^2/hr to mmol C/s
+    return e * photosynthesis_var * A / (day * 12 * 0.001)  # gC/dm^2/hr to mmol C/s
 end 
 
-@inline (kelp::SugarKelp)(::Val{:DON}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR) =
-    kelp(Val(:DOC), t, A, N, C, u, v, w, T, NO₃, NH₄, PAR) / kelp.exudation_redfield_ratio
+@inline (kelp::SugarKelp)(::Val{:DON}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var) =
+    kelp(Val(:DOC), t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var) / kelp.exudation_redfield_ratio
 
-@inline function (kelp::SugarKelp)(::Val{:bPON}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
+@inline function (kelp::SugarKelp)(::Val{:bPON}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
     kₐ = kelp.structural_dry_weight_per_area
     Nₛ = kelp.structural_nitrogen
 
@@ -47,7 +45,7 @@ end
 end 
 
 # this is why the particles made by kelp can be much more carbon rich
-@inline function (kelp::SugarKelp)(::Val{:bPOC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
+@inline function (kelp::SugarKelp)(::Val{:bPOC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR, photosynthesis_var)
     kₐ = kelp.structural_dry_weight_per_area
     Cₛ = kelp.structural_carbon
 

--- a/src/Particles/Particles.jl
+++ b/src/Particles/Particles.jl
@@ -63,39 +63,9 @@ varables.
 buffer_variables(particle_bgc) = ()
 
 
-"""
-    compute_buffer_variable(::Val{:buffer_variable}, biogeochemistry, tracers...)
-
-Function each model needs to implement to compute a `:buffer_variable` in the buffer.
-
-`tracers` contains value of all tracer fields declared by `required_tracers` method for
-the model.
-"""
-function compute_buffer_variable end
-
-@inline function fill_all_buffer_variables!(particles::BiogeochemicalParticles{N}, model) where N
-
-    dev = device(architecture(model))
-
-    workgroup = min(N, 256)
-    worksize = N
-    kernel! = fill_single_buffer_variable!(dev, workgroup, worksize)
-
-    for variable in buffer_variables(particles.biogeochemistry)
-        kernel!(particles.buffer[variable], Val(variable), particles, model.grid, fields(model))
-    end
-end
-
-@kernel function fill_single_buffer_variable!(buffer, variable_name, particles, grid, fields)
-    n = @index(Global) 
-    tracer_values = extract_tracer_values(variable_name, particles.field_interpolation, particles, grid, fields, n)
-    @inbounds buffer[n] = compute_buffer_variable(variable_name, particles.biogeochemistry, tracer_values...)
-    nothing
-end
-
-
 include("atomic_operations.jl")
 include("advection.jl")
+include("fill_buffer.jl")
 include("tracer_interpolation.jl")
 include("tendencies.jl")
 include("time_stepping.jl")

--- a/src/Particles/fill_buffer.jl
+++ b/src/Particles/fill_buffer.jl
@@ -1,0 +1,31 @@
+"""
+    compute_buffer_variable(::Val{:buffer_variable}, biogeochemistry, tracers...)
+
+Function each model needs to implement to compute a `:buffer_variable` in the buffer.
+
+`tracers` contains value of all tracer fields declared by `required_tracers` method for
+the model.
+"""
+function compute_buffer_variable end
+
+@inline function fill_all_buffer_variables!(particles::BiogeochemicalParticles{N}, model) where N
+
+    dev = device(architecture(model))
+
+    workgroup = min(N, 256)
+    worksize = N
+    kernel! = fill_single_buffer_variable!(dev, workgroup, worksize)
+
+    for variable in buffer_variables(particles.biogeochemistry)
+        kernel!(particles.buffer[variable], Val(variable), particles, model.grid, fields(model))
+    end
+
+    return nothing
+end
+
+@kernel function fill_single_buffer_variable!(buffer, variable_name, particles, grid, fields)
+    n = @index(Global) 
+    tracer_values = extract_tracer_values(variable_name, particles.field_interpolation, particles, grid, fields, n)
+    @inbounds buffer[n] = compute_buffer_variable(variable_name, particles.biogeochemistry, tracer_values...)
+    nothing
+end

--- a/src/Particles/tendencies.jl
+++ b/src/Particles/tendencies.jl
@@ -1,6 +1,9 @@
 using Oceananigans: fields
 
 function compute_particle_tendencies!(particles::BiogeochemicalParticles{N}, model) where N
+
+    fill_all_buffer_variables!(particles, model)
+
     tendencies = particles.timestepper.tendencies
 
     field_names = required_particle_fields(particles)
@@ -31,5 +34,7 @@ end
 
     tracer_values = extract_tracer_values(val_field_name, particles.field_interpolation, particles, grid, fields, n)
 
-    tendencies[field_name][n] = particles.biogeochemistry(val_field_name, t, field_values..., tracer_values...)
+    buffer_values = map(x -> x[n], particles.buffer)
+
+    tendencies[field_name][n] = particles.biogeochemistry(val_field_name, t, field_values..., tracer_values..., buffer_values...)
 end

--- a/src/Particles/update_tracer_tendencies.jl
+++ b/src/Particles/update_tracer_tendencies.jl
@@ -1,4 +1,7 @@
 function update_tendencies!(bgc, particles::BiogeochemicalParticles{N}, model) where N
+
+    fill_all_buffer_variables!(particles, model)
+
     field_names = coupled_tracers(particles)
 
     dev = device(architecture(model))

--- a/src/Particles/update_tracer_tendencies.jl
+++ b/src/Particles/update_tracer_tendencies.jl
@@ -41,7 +41,9 @@ possible_tuple_value(::Tuple, field_name) = field_name
 
     tracer_values = extract_tracer_values(val_field_name, particles.field_interpolation, particles, grid, fields, n)
 
-    particle_tendency = particles.biogeochemistry(val_field_name, t, field_values..., tracer_values...) 
+    buffer_values = map(x -> x[n], particles.buffer)
+
+    particle_tendency = particles.biogeochemistry(val_field_name, t, field_values..., tracer_values..., buffer_values...)
 
     scalefactor = @inbounds scalefactors[n]
 


### PR DESCRIPTION
Resolves #321 

Basically it allows a biogeochemical model in the particles to declare buffer for some heavy-to-compute (i.e. `photosynthesis` function result) variables so they can be reused across multiple kernels that update tendencies for the tracers and particle fields. 

In contrast to what I said in #321, the buffers need to be filled twice since particle move between tracer and fields tendencies are updated. 

It is still a draft so we can discuss alternative/better way to introduce buffers. In particular the following points: 
- At the moment there is no differentiation between a buffer variables  for update of tracer and field tendencies, but in principle different set of variables may be needed. Should we try to have separate `buffer_variable` registration and filling for these steps? 
- I wasn't sure where the kernel that does the filling should be defined. At the moment it stayed in `Particle` and just delegates to a function provided by a specific `Model/Individual`. But I was wondering if the kernel should not be defined by a specific model so it can be optimised/tailored more to calculation of the specific buffer variable... 

The performance change will follow in the post shortly. 

TODO: 
- [x] add unit tests for buffers 