### PR TITLE
Specialise on the parameter values

### DIFF
--- a/src/Models/Individuals/SugarKelp/SugarKelp.jl
+++ b/src/Models/Individuals/SugarKelp/SugarKelp.jl
@@ -26,7 +26,7 @@ using OceanBioME: NewtonRaphsonSolver
 using OceanBioME.Particles: BiogeochemicalParticles
 
 import OceanBioME.Particles: required_particle_fields, required_tracers, coupled_tracers
-import OceanBioME: UnwrapValueFields
+import OceanBioME: UnwrapValueFields, CallableVal
 
 
 @kwdef struct SugarKelpParameters{FT}
@@ -85,8 +85,8 @@ end
 Defines the parameters for `SugarKelp` biogeochemistry.
 """
 struct SugarKelp{TL, SO, PS} <: UnwrapValueFields
-                    temperature_limit :: TL
-                    solver :: SO
+                    temperature_limit :: CallableVal{TL}
+                    solver :: CallableVal{SO}
                     params :: Val{PS}
 
     function SugarKelp(FT = Float64; 
@@ -95,7 +95,7 @@ struct SugarKelp{TL, SO, PS} <: UnwrapValueFields
                        kwargs...
                        ) where {TL, SO}
         params = SugarKelpParameters{FT}(; kwargs...)
-        return new{TL, SO, params}(temperature_limit, solver, Val(params))
+        return new{temperature_limit, solver, params}(CallableVal(temperature_limit), CallableVal(solver), Val(params))
     end
 end 
 

--- a/src/Models/Individuals/SugarKelp/SugarKelp.jl
+++ b/src/Models/Individuals/SugarKelp/SugarKelp.jl
@@ -26,133 +26,76 @@ using OceanBioME: NewtonRaphsonSolver
 using OceanBioME.Particles: BiogeochemicalParticles
 
 import OceanBioME.Particles: required_particle_fields, required_tracers, coupled_tracers
+import OceanBioME: UnwrapValueFields
+
+
+@kwdef struct SugarKelpParameters{FT}
+    growth_rate_adjustment :: FT = 4.5
+    photosynthetic_efficiency :: FT = 4.15e-5 * 24 * 10^6 / (24 * 60 * 60)
+    minimum_carbon_reserve :: FT = 0.01
+    structural_carbon :: FT = 0.2
+    exudation :: FT = 0.5
+    erosion_exponent :: FT = 0.22
+    base_erosion_rate :: FT = 10^-6
+    saturation_irradiance :: FT = 90 * day/ (10 ^ 6)
+    structural_dry_weight_per_area :: FT = 0.5
+    structural_dry_to_wet_weight :: FT = 0.0785
+    carbon_reserve_per_carbon :: FT = 2.1213
+    nitrogen_reserve_per_nitrogen :: FT = 2.72
+    minimum_nitrogen_reserve :: FT = 0.0126
+    maximum_nitrogen_reserve :: FT = 0.0216
+    growth_adjustment_2 :: FT = 0.039 / (2 * (1 - minimum_nitrogen_reserve / maximum_nitrogen_reserve))
+    growth_adjustment_1 :: FT = 0.18 / (2 * (1 - minimum_nitrogen_reserve / maximum_nitrogen_reserve)) - growth_adjustment_2
+    maximum_specific_growth_rate :: FT = 0.18
+    structural_nitrogen :: FT = 0.0146
+    photosynthesis_at_ref_temp_1 :: FT = 1.22e-3 * 24
+    photosynthesis_at_ref_temp_2 :: FT = 1.3e-3 * 24
+    photosynthesis_ref_temp_1 :: FT = 285.0
+    photosynthesis_ref_temp_2 :: FT = 288.0
+    photoperiod_1 :: FT = 0.85
+    photoperiod_2 :: FT = 0.3
+    respiration_at_ref_temp_1 :: FT = 2.785e-4 * 24
+    respiration_at_ref_temp_2 :: FT = 5.429e-4 * 24
+    respiration_ref_temp_1 :: FT = 285.0
+    respiration_ref_temp_2 :: FT = 290.0
+    photosynthesis_arrhenius_temp :: FT = (1 / photosynthesis_ref_temp_1 - 1 / photosynthesis_ref_temp_2) ^ -1 * log(photosynthesis_at_ref_temp_2 / photosynthesis_at_ref_temp_1)
+    photosynthesis_low_temp :: FT = 271.0
+    photosynthesis_high_temp :: FT = 296.0
+    photosynthesis_high_arrhenius_temp :: FT = 1414.87
+    photosynthesis_low_arrhenius_temp :: FT = 4547.89
+    respiration_arrhenius_temp :: FT = (1 / respiration_ref_temp_1 - 1 / respiration_ref_temp_2) ^ -1 * log(respiration_at_ref_temp_2 / respiration_at_ref_temp_1)
+    current_speed_for_0p65_uptake :: FT = 0.03
+    nitrate_half_saturation :: FT = 4.0
+    ammonia_half_saturation :: FT = 1.3
+    maximum_nitrate_uptake :: FT = 10 / structural_dry_weight_per_area * 24 * 14 / (10^6)
+    maximum_ammonia_uptake :: FT = 12 / structural_dry_weight_per_area * 24 * 14 / (10^6)
+    current_1 :: FT = 0.72
+    current_2 :: FT = 0.28
+    current_3 :: FT = 0.045
+    base_activity_respiration_rate :: FT = 1.11e-4 * 24
+    base_basal_respiration_rate :: FT = 5.57e-5 * 24
+    exudation_redfield_ratio :: FT = Inf
+    adapted_latitude :: FT = 57.5
+end
+
 
 """
     SugarKelp
 
 Defines the parameters for `SugarKelp` biogeochemistry.
 """
-struct SugarKelp{FT, TL, SO}
-                     temperature_limit :: TL
-                growth_rate_adjustment :: FT
-             photosynthetic_efficiency :: FT
-                minimum_carbon_reserve :: FT
-                     structural_carbon :: FT
-                             exudation :: FT
-                      erosion_exponent :: FT
-                     base_erosion_rate :: FT
-                 saturation_irradiance :: FT
-        structural_dry_weight_per_area :: FT
-          structural_dry_to_wet_weight :: FT
-             carbon_reserve_per_carbon :: FT
-         nitrogen_reserve_per_nitrogen :: FT
-              minimum_nitrogen_reserve :: FT
-              maximum_nitrogen_reserve :: FT
-                   growth_adjustment_2 :: FT
-                   growth_adjustment_1 :: FT
-          maximum_specific_growth_rate :: FT
-                   structural_nitrogen :: FT
-          photosynthesis_at_ref_temp_1 :: FT
-          photosynthesis_at_ref_temp_2 :: FT 
-             photosynthesis_ref_temp_1 :: FT
-             photosynthesis_ref_temp_2 :: FT
-                         photoperiod_1 :: FT
-                         photoperiod_2 :: FT
-             respiration_at_ref_temp_1 :: FT
-             respiration_at_ref_temp_2 :: FT
-                respiration_ref_temp_1 :: FT
-                respiration_ref_temp_2 :: FT
-         photosynthesis_arrhenius_temp :: FT
-               photosynthesis_low_temp :: FT
-              photosynthesis_high_temp :: FT
-    photosynthesis_high_arrhenius_temp :: FT
-     photosynthesis_low_arrhenius_temp :: FT
-            respiration_arrhenius_temp :: FT
-         current_speed_for_0p65_uptake :: FT
-               nitrate_half_saturation :: FT
-               ammonia_half_saturation :: FT
-                maximum_nitrate_uptake :: FT
-                maximum_ammonia_uptake :: FT
-                             current_1 :: FT
-                             current_2 :: FT
-                             current_3 :: FT 
-        base_activity_respiration_rate :: FT
-           base_basal_respiration_rate :: FT
-              exudation_redfield_ratio :: FT
-                      adapted_latitude :: FT
-                                solver :: SO
+struct SugarKelp{TL, SO, PS} <: UnwrapValueFields
+                    temperature_limit :: TL
+                    solver :: SO
+                    params :: Val{PS}
 
     function SugarKelp(FT = Float64; 
                        temperature_limit::TL = LinearOptimalTemperatureRange{FT}(),
-                       growth_rate_adjustment = 4.5,
-                       photosynthetic_efficiency = 4.15e-5 * 24 * 10^6 / (24 * 60 * 60),
-                       minimum_carbon_reserve = 0.01,
-                       structural_carbon = 0.2,
-                       exudation = 0.5,
-                       erosion_exponent = 0.22,
-                       base_erosion_rate = 10^-6,
-                       saturation_irradiance = 90 * day/ (10 ^ 6),
-                       structural_dry_weight_per_area = 0.5,
-                       structural_dry_to_wet_weight = 0.0785,
-                       carbon_reserve_per_carbon = 2.1213,
-                       nitrogen_reserve_per_nitrogen = 2.72,
-                       minimum_nitrogen_reserve = 0.0126,
-                       maximum_nitrogen_reserve = 0.0216,
-                       growth_adjustment_2 = 0.039 / (2 * (1 - minimum_nitrogen_reserve / maximum_nitrogen_reserve)),
-                       growth_adjustment_1 = 0.18 / (2 * (1 - minimum_nitrogen_reserve / maximum_nitrogen_reserve)) - growth_adjustment_2,
-                       maximum_specific_growth_rate = 0.18,
-                       structural_nitrogen = 0.0146,
-                       photosynthesis_at_ref_temp_1 = 1.22e-3 * 24,
-                       photosynthesis_at_ref_temp_2 = 1.3e-3 * 24,
-                       photosynthesis_ref_temp_1 = 285.0,
-                       photosynthesis_ref_temp_2 = 288.0,
-                       photoperiod_1 = 0.85,
-                       photoperiod_2 = 0.3,
-                       respiration_at_ref_temp_1 = 2.785e-4 * 24,
-                       respiration_at_ref_temp_2 = 5.429e-4 * 24,
-                       respiration_ref_temp_1 = 285.0,
-                       respiration_ref_temp_2 = 290.0,
-                       photosynthesis_arrhenius_temp = (1 / photosynthesis_ref_temp_1 - 1 / photosynthesis_ref_temp_2) ^ -1 * log(photosynthesis_at_ref_temp_2 / photosynthesis_at_ref_temp_1),
-                       photosynthesis_low_temp = 271.0,
-                       photosynthesis_high_temp = 296.0,
-                       photosynthesis_high_arrhenius_temp = 1414.87,
-                       photosynthesis_low_arrhenius_temp = 4547.89,
-                       respiration_arrhenius_temp = (1 / respiration_ref_temp_1 - 1 / respiration_ref_temp_2) ^ -1 * log(respiration_at_ref_temp_2 / respiration_at_ref_temp_1),
-                       current_speed_for_0p65_uptake = 0.03,
-                       nitrate_half_saturation = 4.0,
-                       ammonia_half_saturation = 1.3,
-                       maximum_nitrate_uptake = 10 / structural_dry_weight_per_area * 24 * 14 / (10^6),
-                       maximum_ammonia_uptake = 12 / structural_dry_weight_per_area * 24 * 14 / (10^6),
-                       current_1 = 0.72,
-                       current_2 = 0.28,
-                       current_3 = 0.045,
-                       base_activity_respiration_rate = 1.11e-4 * 24,
-                       base_basal_respiration_rate = 5.57e-5 * 24,
-                       exudation_redfield_ratio = Inf,
-                       adapted_latitude = 57.5,
-                       solver::SO = NewtonRaphsonSolver{FT, Int}(; atol = eps(FT(1e-9)))) where {TL, SO}
-
-        return new{FT, TL, SO}(temperature_limit, 
-                               growth_rate_adjustment, photosynthetic_efficiency,
-                               minimum_carbon_reserve, structural_carbon,
-                               exudation, erosion_exponent, base_erosion_rate,
-                               saturation_irradiance,
-                               structural_dry_weight_per_area, structural_dry_to_wet_weight,
-                               carbon_reserve_per_carbon, nitrogen_reserve_per_nitrogen,
-                               minimum_nitrogen_reserve, maximum_nitrogen_reserve,
-                               growth_adjustment_2, growth_adjustment_1, maximum_specific_growth_rate,
-                               structural_nitrogen,
-                               photosynthesis_at_ref_temp_1, photosynthesis_at_ref_temp_2,
-                               photosynthesis_ref_temp_1, photosynthesis_ref_temp_2, photoperiod_1, photoperiod_2,
-                               respiration_at_ref_temp_1, respiration_at_ref_temp_2, respiration_ref_temp_1, respiration_ref_temp_2,
-                               photosynthesis_arrhenius_temp, photosynthesis_low_temp, photosynthesis_high_temp,
-                               photosynthesis_high_arrhenius_temp, photosynthesis_low_arrhenius_temp,
-                               respiration_arrhenius_temp,
-                               current_speed_for_0p65_uptake, nitrate_half_saturation, ammonia_half_saturation,
-                               maximum_nitrate_uptake, maximum_ammonia_uptake, current_1, current_2, current_3, 
-                               base_activity_respiration_rate, base_basal_respiration_rate, exudation_redfield_ratio,
-                               adapted_latitude, 
-                               solver)
+                       solver::SO = NewtonRaphsonSolver{FT, Int}(; atol = eps(FT(1e-9))),
+                       kwargs...
+                       ) where {TL, SO}
+        params = SugarKelpParameters{FT}(; kwargs...)
+        return new{TL, SO, params}(temperature_limit, solver, Val(params))
     end
 end 
 

--- a/src/Models/Individuals/SugarKelp/coupling.jl
+++ b/src/Models/Individuals/SugarKelp/coupling.jl
@@ -35,11 +35,11 @@ end
 end 
 
 @inline (kelp::SugarKelp)(::Val{:DON}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR) =
-    kelp(Val(:DOC), t, A, N, C, u, v, w, T, NO₃, NH₄, PAR) / kelp.exudation_redfield_ratio
+    kelp(Val(:DOC), t, A, N, C, u, v, w, T, NO₃, NH₄, PAR) / kelp.params.exudation_redfield_ratio
 
 @inline function (kelp::SugarKelp)(::Val{:bPON}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
-    kₐ = kelp.structural_dry_weight_per_area
-    Nₛ = kelp.structural_nitrogen
+    kₐ = kelp.params.structural_dry_weight_per_area
+    Nₛ = kelp.params.structural_nitrogen
 
     ν = erosion(kelp, t, A, N, C, T)
 
@@ -48,8 +48,8 @@ end
 
 # this is why the particles made by kelp can be much more carbon rich
 @inline function (kelp::SugarKelp)(::Val{:bPOC}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
-    kₐ = kelp.structural_dry_weight_per_area
-    Cₛ = kelp.structural_carbon
+    kₐ = kelp.params.structural_dry_weight_per_area
+    Cₛ = kelp.params.structural_carbon
 
     ν = erosion(kelp, t, A, N, C, T)
 

--- a/src/Models/Individuals/SugarKelp/equations.jl
+++ b/src/Models/Individuals/SugarKelp/equations.jl
@@ -7,8 +7,8 @@
 end
 
 @inline function (kelp::SugarKelp)(::Val{:N}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
-    kₐ = kelp.structural_dry_weight_per_area
-    Nₛ = kelp.structural_nitrogen
+    kₐ = kelp.params.structural_dry_weight_per_area
+    Nₛ = kelp.params.structural_nitrogen
 
     J = nitrate_uptake(kelp, N, NO₃, u, v, w) +
         ammonia_uptake(kelp, t, A, N, C, T, NH₄, u, v, w)
@@ -21,8 +21,8 @@ end
 end
 
 @inline function (kelp::SugarKelp)(::Val{:C}, t, A, N, C, u, v, w, T, NO₃, NH₄, PAR)
-    kₐ = kelp.structural_dry_weight_per_area
-    Cₛ = kelp.structural_carbon
+    kₐ = kelp.params.structural_dry_weight_per_area
+    Cₛ = kelp.params.structural_carbon
 
     P = photosynthesis(kelp, T, PAR)
 
@@ -39,11 +39,11 @@ end
     f = base_growth_limitation(kelp, t, A, N, C, T)
 
     # potential ammonia based_growth
-    kₐ = kelp.structural_dry_weight_per_area
-    Nₛ = kelp.structural_nitrogen
+    kₐ = kelp.params.structural_dry_weight_per_area
+    Nₛ = kelp.params.structural_nitrogen
 
-    Nₘ = kelp.minimum_nitrogen_reserve
-    Cₘ = kelp.minimum_carbon_reserve
+    Nₘ = kelp.params.minimum_nitrogen_reserve
+    Cₘ = kelp.params.minimum_carbon_reserve
     
     j̃_NH₄ = potential_ammonia_uptake(kelp, NH₄, u, v, w)
     
@@ -57,12 +57,12 @@ end
 end
 
 @inline function nitrate_uptake(kelp, N, NO₃, u, v, w)
-    J_max_NO₃ = kelp.maximum_nitrate_uptake
+    J_max_NO₃ = kelp.params.maximum_nitrate_uptake
 
-    k_NO₃ = kelp.nitrate_half_saturation
+    k_NO₃ = kelp.params.nitrate_half_saturation
 
-    N_max = kelp.maximum_nitrogen_reserve
-    N_min = kelp.minimum_nitrogen_reserve
+    N_max = kelp.params.maximum_nitrogen_reserve
+    N_min = kelp.params.minimum_nitrogen_reserve
 
     fᶜ = current_factor(kelp, u, v, w)
 
@@ -70,8 +70,8 @@ end
 end
 
 @inline function ammonia_uptake(kelp, t, A, N, C, T, NH₄, u, v, w)
-    kₐ = kelp.structural_dry_weight_per_area
-    Nₛ = kelp.structural_nitrogen
+    kₐ = kelp.params.structural_dry_weight_per_area
+    Nₛ = kelp.params.structural_nitrogen
 
     j̃_NH₄ = potential_ammonia_uptake(kelp, NH₄, u, v, w)
 
@@ -81,8 +81,8 @@ end
 end
 
 @inline function potential_ammonia_uptake(kelp, NH₄, u, v, w)
-    J_max_NH₄ = kelp.maximum_ammonia_uptake
-    k_NH₄ = kelp.ammonia_half_saturation
+    J_max_NH₄ = kelp.params.maximum_ammonia_uptake
+    k_NH₄ = kelp.params.ammonia_half_saturation
     
     fᶜ = current_factor(kelp, u, v, w)
 
@@ -94,18 +94,18 @@ end
 
     Tk = T + 273.15
 
-    P₁ = kelp.photosynthesis_at_ref_temp_1
+    P₁ = kelp.params.photosynthesis_at_ref_temp_1
 
-    Tₐ  = kelp.photosynthesis_arrhenius_temp
-    Tₐₗ = kelp.photosynthesis_low_arrhenius_temp
-    Tₐₕ = kelp.photosynthesis_high_arrhenius_temp
+    Tₐ  = kelp.params.photosynthesis_arrhenius_temp
+    Tₐₗ = kelp.params.photosynthesis_low_arrhenius_temp
+    Tₐₕ = kelp.params.photosynthesis_high_arrhenius_temp
 
-    Tₚ  = kelp.photosynthesis_ref_temp_1
-    Tₚₗ = kelp.photosynthesis_ref_temp_1
-    Tₚₕ = kelp.photosynthesis_high_temp
+    Tₚ  = kelp.params.photosynthesis_ref_temp_1
+    Tₚₗ = kelp.params.photosynthesis_ref_temp_1
+    Tₚₕ = kelp.params.photosynthesis_high_temp
 
-    α = kelp.photosynthetic_efficiency
-    Iₛ = kelp.saturation_irradiance
+    α = kelp.params.photosynthetic_efficiency
+    Iₛ = kelp.params.saturation_irradiance
 
     maximum_photosynthesis = P₁ * exp(Tₐ / Tₚ - Tₐ / Tk) / (1 + exp(Tₐₗ / Tk - Tₐₗ / Tₚₗ) + exp(Tₐₕ / Tₚₕ - Tₐₕ / Tk))
  
@@ -118,8 +118,8 @@ end
 
 
 @inline function solve_for_light_inhibition(kelp, Pₘ::FT) where FT
-    α = kelp.photosynthetic_efficiency
-    Iₛ = kelp.saturation_irradiance
+    α = kelp.params.photosynthetic_efficiency
+    Iₛ = kelp.params.saturation_irradiance
 
     β₀ = convert(FT, 1e-9)
 
@@ -139,18 +139,18 @@ maximum_photosynthesis(α, β) = α / (log(1 + α/β)) * (α / (α + β)) * (β 
 end
 
 @inline function respiration(kelp, t, A, N, C, T, NO₃, NH₄, u, v, w, μ)
-    Rᵇ = kelp.base_basal_respiration_rate
-    Rᵃ = kelp.base_activity_respiration_rate
+    Rᵇ = kelp.params.base_basal_respiration_rate
+    Rᵃ = kelp.params.base_activity_respiration_rate
 
-    Tₐ = kelp.respiration_arrhenius_temp
-    T₁ = kelp.respiration_ref_temp_1
+    Tₐ = kelp.params.respiration_arrhenius_temp
+    T₁ = kelp.params.respiration_ref_temp_1
 
     Tk = T + 273.15
 
     f = exp(Tₐ / T₁ - Tₐ / Tk)
 
-    μₘ = kelp.maximum_specific_growth_rate
-    Jₘ = kelp.maximum_nitrate_uptake + kelp.maximum_ammonia_uptake
+    μₘ = kelp.params.maximum_specific_growth_rate
+    Jₘ = kelp.params.maximum_nitrate_uptake + kelp.params.maximum_ammonia_uptake
 
     J = nitrate_uptake(kelp, N, NO₃, u, v, w) +
         ammonia_uptake(kelp, t, A, N, C, T, NH₄, u, v, w)
@@ -159,14 +159,14 @@ end
 end
 
 @inline function specific_carbon_exudate(kelp, C)
-    γ = kelp.exudation
-    Cₘ = kelp.minimum_carbon_reserve
+    γ = kelp.params.exudation
+    Cₘ = kelp.params.minimum_carbon_reserve
 
     return 1 - exp(γ * (Cₘ - C))
 end
 
 @inline function nitrogen_exudate(kelp, C, T, PAR)
-    CN = kelp.exudation_redfield_ratio
+    CN = kelp.params.exudation_redfield_ratio
 
     P = photosynthesis(kelp, T, PAR)
     e = specific_carbon_exudate(kelp, C)
@@ -175,16 +175,16 @@ end
 end
 
 @inline function erosion(kelp, t, A, N, C, T)
-    ε = kelp.erosion_exponent
-    ν₀ = kelp.base_erosion_rate
+    ε = kelp.params.erosion_exponent
+    ν₀ = kelp.params.base_erosion_rate
 
     return ν₀ * exp(ε * A) / (1 + ν₀ * (exp(ε * A) - 1))
 end
 
 @inline function current_factor(kelp, u, v, w)
-    f₁ = kelp.current_1
-    f₂ = kelp.current_2
-    f₃ = kelp.current_3
+    f₁ = kelp.params.current_1
+    f₂ = kelp.params.current_2
+    f₃ = kelp.params.current_3
 
     U = √(u^2 + v^2 + w^2)
     
@@ -200,9 +200,9 @@ end
 end
 
 @inline function area_limitation(kelp, A)
-    A₀ = kelp.growth_rate_adjustment
-    m₁ = kelp.growth_adjustment_1
-    m₂ = kelp.growth_adjustment_2
+    A₀ = kelp.params.growth_rate_adjustment
+    m₁ = kelp.params.growth_adjustment_1
+    m₂ = kelp.params.growth_adjustment_2
 
     return m₁ * exp(-(A / A₀)^2) + m₂
 end
@@ -230,9 +230,9 @@ end
 
 # the kelp magically know what day of the year it is!!!
 @inline function seasonal_limitation(kelp, t)
-    φ = kelp.adapted_latitude
-    a₁ = kelp.photoperiod_1
-    a₂ = kelp.photoperiod_2
+    φ = kelp.params.adapted_latitude
+    a₁ = kelp.params.photoperiod_1
+    a₂ = kelp.params.photoperiod_2
 
     n = floor(Int, mod(t, 364days)/day)
 

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -4,6 +4,7 @@ include("timestep.jl")
 include("negative_tracers.jl")
 include("sinking_velocity_fields.jl")
 include("solvers.jl")
+include("unwrapvaluefields.jl")
 
 """
     (day_length::CBMDayLength)(t, φ)

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -1,5 +1,6 @@
 using Oceananigans.Units
 
+include("callablevalue.jl")
 include("timestep.jl")
 include("negative_tracers.jl")
 include("sinking_velocity_fields.jl")

--- a/src/Utils/callablevalue.jl
+++ b/src/Utils/callablevalue.jl
@@ -1,0 +1,5 @@
+struct CallableVal{V} end
+
+CallableVal(x) = CallableVal{x}()
+
+(::CallableVal{V})(args...; kwargs...) where {V} = V(args...; kwargs...)

--- a/src/Utils/unwrapvaluefields.jl
+++ b/src/Utils/unwrapvaluefields.jl
@@ -11,6 +11,9 @@ abstract type UnwrapValueFields end
 unwrap_value(::Val{V}) where {V} = V
 unwrap_value(v) = v
 
+# One expects CallableValue we defined internaly to also be unwraped
+unwrap_value(::CallableVal{V}) where {V} = V
+
 Base.getproperty(p::UnwrapValueFields, s::Symbol) = unwrap_value(Base.getfield(p, s))
 
 

--- a/src/Utils/unwrapvaluefields.jl
+++ b/src/Utils/unwrapvaluefields.jl
@@ -1,0 +1,18 @@
+"""
+Make it superclass of a struct to unwrap fields such that typeof(field) == Val{V}
+and make the dot access 's.value_field' return the value V inside Val{V}.
+
+Ideally it would be a trait to avoid having to put it in a type hierarchy, but 
+for that we would need to commit gross act of type piracy overriding 
+`Base.getproperty`.
+"""
+abstract type UnwrapValueFields end
+
+unwrap_value(::Val{V}) where {V} = V
+unwrap_value(v) = v
+
+Base.getproperty(p::UnwrapValueFields, s::Symbol) = unwrap_value(Base.getfield(p, s))
+
+
+
+


### PR DESCRIPTION
Related to #320. 

It is marked as draft since it is intended to be a starting point for the discussion on whether something like that should be merged into the code, and to show off some proposal on how it can be done. Hence, I have only applied it to the `SugarKelp`

In terms of performance, as discussed in the issue, it doesn't seem to give much. As expected, the register usage is significantly reduced, but it is not enough to increase occupancy. Small saving related to the fact that some computation can be compile-time evaluated is minimal (<2%) and on the verge of measurable. Based on that alone I would say it is probably not worth the effort... but on the other hand, for some kernels, in some circumstances, it may be enough to push a kernel to the higher occupancy band, and the performance improvements when that happens can be significant :-/ 

In terms of implementation I went with what I thought to be least invasive, which is to move numeric parameters to separate `@kwdef` struct and embed it as a parameter of the model struct (as suggested by @glwagner). Then, to 'unwrap'  the value from `Val{V}` when using `.` (`getproperty`) access automatically, the model struct can subtype `UnwrapValueFields`. I wish it could be done with a 'Holy Trait', but it would result horrible type piracy (specialising `Base.getproperty(::Any, ::Symbol)` :pirate_flag: :grimacing: ). 

The alternative would be to use a custom 'property-getter' function. I went with what I went, but I don't have any preference for either. 

For the callable types, I have added a custom `Val` parametric type so they will be automatically unwrapped when called. As far as I am able to tell (looking into the generated code + poking it with `@code_...` macros) it does specialise the call for an instance. But I am still a bit uneasy if there isn't some subtle trap/edge case lurking around.       

