### PR TITLE
Allows surface light to be functions or fields

### DIFF
--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -129,6 +129,7 @@ function TwoBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
                             regularize_field_boundary_conditions(
                                 FieldBoundaryConditions(top = ValueBoundaryCondition(surface_PAR)), grid, :PAR))
 
+    # wrap surface_PAR to make it work with the `getbc` interface
     surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, ()) 
     surface_PAR = regularize_boundary_condition(surface_PAR, grid, (Center(), Center(), Center()), 3, RightBoundary, nothing)
 

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,11 +1,9 @@
-@kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, P, surface_PAR, t, PAR_model)
+@kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, clock, P, surface_PAR, PAR_model)
     i, j = @index(Global, NTuple)
 
     k, k′ = domain_boundary_indices(RightBoundary(), grid.Nz)
 
-    X = z_boundary_node(i, j, k′, grid, Center(), Center())
-
-    PAR⁰ = surface_PAR(X..., t)
+    PAR⁰ = getbc(surface_PAR, i, j, grid, clock, P)
 
     kʳ = PAR_model.water_red_attenuation
     kᵇ = PAR_model.water_blue_attenuation
@@ -90,9 +88,22 @@ Keyword Arguments
 
 - `grid`: grid for building the model on
 - `water_red_attenuation`, ..., `phytoplankton_chlorophyll_ratio`: parameter values
-- `surface_PAR`: function (or array in the future) for the photosynthetically available radiation at the surface,
-   which should be `f(x, y, t)` where `x` and `y` are the native coordinates (i.e. meters for rectilinear grids
-   and latitude/longitude as appropriate)
+- `surface_PAR`: the photosynthetically available radiation at the surface, by default,
+   assumed to have the 'continuous form' `condition(x, y t)`
+
+If `parameters` is not `nothing`, then `surface_PAR` has the form
+`func(x, y, t, parameters)`.
+
+If `discrete_form = true`, surface_PAR is assumed to have the "discrete form",
+```
+condition(i, j, grid, clock, fields)
+```
+where `i`, and `j` are indices that vary along the boundary. If `discrete_form = true` and
+`parameters` is not `nothing`, the function `condition` is called with
+```
+condition(i, j, grid, clock, fields, parameters)
+```
+
 """
 function TwoBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
                                                     water_red_attenuation = 0.225, # 1/m
@@ -103,7 +114,9 @@ function TwoBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
                                                     chlorophyll_blue_exponent = 0.674,
                                                     pigment_ratio = 0.7,
                                                     phytoplankton_chlorophyll_ratio = 1.31,
-                                                    surface_PAR = default_surface_PAR) where FT
+                                                    surface_PAR = default_surface_PAR,
+                                                    discrete_form = false,
+                                                    parameters = nothing) where FT
 
     water_red_attenuation = convert(FT, water_red_attenuation)
     water_blue_attenuation = convert(FT, water_blue_attenuation)
@@ -117,6 +130,9 @@ function TwoBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
     field = CenterField(grid; boundary_conditions =
                             regularize_field_boundary_conditions(
                                 FieldBoundaryConditions(top = ValueBoundaryCondition(surface_PAR)), grid, :PAR))
+
+    surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, nothing) 
+    surface_PAR = regularize_boundary_condition(surface_PAR, grid, (Center(), Center(), Center()), 3, RightBoundary, nothing)
 
     return TwoBandPhotosyntheticallyActiveRadiation(water_red_attenuation,
                                                     water_blue_attenuation,
@@ -132,9 +148,11 @@ end
 
 function update_biogeochemical_state!(model, PAR::TwoBandPhotosyntheticallyActiveRadiation)
     arch = architecture(model.grid)
-    launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.tracers.P, PAR.surface_PAR, model.clock.time, PAR)
 
+    launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.clock, model.tracers.P, PAR.surface_PAR, PAR)
     fill_halo_regions!(PAR.field, model.clock, fields(model))
+
+    return nothing
 end
 
 summary(::TwoBandPhotosyntheticallyActiveRadiation{FT}) where {FT} = string("Two-band light attenuation model ($FT)")

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -131,7 +131,7 @@ function TwoBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
                             regularize_field_boundary_conditions(
                                 FieldBoundaryConditions(top = ValueBoundaryCondition(surface_PAR)), grid, :PAR))
 
-    surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, nothing) 
+    surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, ()) 
     surface_PAR = regularize_boundary_condition(surface_PAR, grid, (Center(), Center(), Center()), 3, RightBoundary, nothing)
 
     return TwoBandPhotosyntheticallyActiveRadiation(water_red_attenuation,
@@ -150,7 +150,7 @@ function update_biogeochemical_state!(model, PAR::TwoBandPhotosyntheticallyActiv
     arch = architecture(model.grid)
 
     launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.clock, model.tracers.P, PAR.surface_PAR, PAR)
-    fill_halo_regions!(PAR.field, model.clock, fields(model))
+    #fill_halo_regions!(PAR.field, model.clock, fields(model))
 
     return nothing
 end

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,8 +1,6 @@
 @kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, clock, P, surface_PAR, PAR_model)
     i, j = @index(Global, NTuple)
 
-    k, k′ = domain_boundary_indices(RightBoundary(), grid.Nz)
-
     PAR⁰ = getbc(surface_PAR, i, j, grid, clock, P)
 
     kʳ = PAR_model.water_red_attenuation

--- a/src/Light/Light.jl
+++ b/src/Light/Light.jl
@@ -22,7 +22,11 @@ using Oceananigans.BoundaryConditions: fill_halo_regions!,
                                        ContinuousBoundaryFunction,
                                        z_boundary_node,
                                        domain_boundary_indices,
-                                       RightBoundary
+                                       RightBoundary,
+                                       getbc, 
+                                       materialize_condition,
+                                       regularize_boundary_condition
+
 using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid
 using OceanBioME: chlorophyll
 

--- a/src/Light/multi_band.jl
+++ b/src/Light/multi_band.jl
@@ -86,7 +86,9 @@ function MultiBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
                                                       base_chlorophyll_attenuation_coefficient = MOREL_χ,
                                                       field_names = ntuple(n->par_symbol(n), Val(length(bands))),
                                                       surface_PAR = default_surface_PAR,
-                                                      surface_PAR_division = fill(1 / length(bands), length(bands))) where FT
+                                                      discrete_form = false,
+                                                      parameters = nothing,
+                                                      surface_PAR_division = fill(1 / length(bands), length(bands)),) where FT
     Nbands = length(bands)
 
     kʷ = zeros(eltype(grid), Nbands)
@@ -118,7 +120,7 @@ function MultiBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
 
     total_PAR = sum(fields)
 
-    surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, nothing) 
+    surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, ()) 
     surface_PAR = regularize_boundary_condition(surface_PAR, grid, (Center(), Center(), Center()), 3, RightBoundary, nothing)
 
     return MultiBandPhotosyntheticallyActiveRadiation(total_PAR,
@@ -143,17 +145,17 @@ end
     ntuple(n->Symbol(Char('\xe2\x82\x80'+digits[n])), Val(N))
 
 @kernel function update_MultiBandPhotosyntheticallyActiveRadiation!(grid, clock, field, kʷ, e, χ,
-                                                                    _surface_PAR, surface_PAR_division, 
+                                                                    _surface_PAR, 
                                                                     Chl, k′) 
     i, j = @index(Global, NTuple)
 
-    surface_PAR = getbc(_surface_PAR, i, j, grid, clock, P)
+    surface_PAR = getbc(_surface_PAR, i, j, grid, clock, field)
 
     zᶜ = znodes(grid, Center(), Center(), Center())
 
     # first point below surface
     k = grid.Nz
-    @inbounds field[i, j, k] = surface_PAR * surface_PAR_division * exp(zᶜ[grid.Nz] * (kʷ + χ * Chl[i, j, k] ^ e))
+    @inbounds field[i, j, k] = surface_PAR * exp(zᶜ[grid.Nz] * (kʷ + χ * Chl[i, j, k] ^ e))
 
     # the rest of the points
     for k in grid.Nz-1:-1:1

--- a/src/Light/multi_band.jl
+++ b/src/Light/multi_band.jl
@@ -76,7 +76,6 @@ where `i`, and `j` are indices that vary along the boundary. If `discrete_form =
 condition(i, j, grid, clock, fields, parameters)
 ```
 
-
 """
 function MultiBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT}, 
                                                       bands = ((400, 500), (500, 600), (600, 700)), #nm
@@ -139,14 +138,13 @@ function numerical_mean(λ, C, idx1, idx2)
     return ∫Cdλ / ∫dλ
 end
 
-@inline par_symbol(n) = Symbol(:PAR, Char('\xe2\x82\x80'+n)) #Symbol(:PAR, number_subscript(tuple(reverse(digits(n))...))...)
+@inline par_symbol(n) = Symbol(:PAR, Char('\xe2\x82\x80'+n)) 
 
 @inline number_subscript(digits::NTuple{N}) where N =
     ntuple(n->Symbol(Char('\xe2\x82\x80'+digits[n])), Val(N))
 
 @kernel function update_MultiBandPhotosyntheticallyActiveRadiation!(grid, clock, field, kʷ, e, χ,
-                                                                    _surface_PAR, 
-                                                                    Chl, k′) 
+                                                                    _surface_PAR, surface_PAR_division, Chl) 
     i, j = @index(Global, NTuple)
 
     surface_PAR = getbc(_surface_PAR, i, j, grid, clock, field)
@@ -155,7 +153,7 @@ end
 
     # first point below surface
     k = grid.Nz
-    @inbounds field[i, j, k] = surface_PAR * exp(zᶜ[grid.Nz] * (kʷ + χ * Chl[i, j, k] ^ e))
+    @inbounds field[i, j, k] = surface_PAR * surface_PAR_division * exp(zᶜ[grid.Nz] * (kʷ + χ * Chl[i, j, k] ^ e))
 
     # the rest of the points
     for k in grid.Nz-1:-1:1
@@ -169,9 +167,7 @@ function update_biogeochemical_state!(model, PAR::MultiBandPhotosyntheticallyAct
 
     arch = architecture(grid)
 
-    _, k′ = domain_boundary_indices(RightBoundary(), grid.Nz)
-
-    for (n, field) in enumerate(PAR.fields)
+    @inbounds for (n, field) in enumerate(PAR.fields)
         launch!(arch, grid, :xy, 
                 update_MultiBandPhotosyntheticallyActiveRadiation!, grid, model.clock,
                 field,
@@ -180,8 +176,7 @@ function update_biogeochemical_state!(model, PAR::MultiBandPhotosyntheticallyAct
                 PAR.chlorophyll_attenuation_coefficient[n], 
                 PAR.surface_PAR, 
                 PAR.surface_PAR_division[n], 
-                chlorophyll(model.biogeochemistry, model), 
-                k′)
+                chlorophyll(model.biogeochemistry, model))
     end
 
     #for field in PAR.fields
@@ -195,7 +190,7 @@ summary(par::MultiBandPhotosyntheticallyActiveRadiation) =
 show(io::IO, model::MultiBandPhotosyntheticallyActiveRadiation) = print(io, summary(model))
 
 biogeochemical_auxiliary_fields(par::MultiBandPhotosyntheticallyActiveRadiation) = 
-    merge((PAR = par.total, ), par.fields)#NamedTuple{field_names(par.field_names, par.fields)}(par.fields))
+    merge((PAR = par.total, ), par.fields)
 
 @inline field_names(field_names, fields) = field_names
 @inline field_names(::Nothing, fields::NTuple{N}) where N = ntuple(n -> par_symbol(n), Val(N))

--- a/src/Light/multi_band.jl
+++ b/src/Light/multi_band.jl
@@ -60,9 +60,22 @@ Keyword Arguments
 
 - `grid`: grid for building the model on
 - `water_red_attenuation`, ..., `phytoplankton_chlorophyll_ratio`: parameter values
-- `surface_PAR`: function (or array in the future) for the photosynthetically available radiation at the surface, 
-   which should be `f(x, y, t)` where `x` and `y` are the native coordinates (i.e. meters for rectilinear grids
-   and latitude/longitude as appropriate)
+- `surface_PAR`: the photosynthetically available radiation at the surface, by default,
+   assumed to have the 'continuous form' `condition(x, y t)`
+
+If `parameters` is not `nothing`, then `surface_PAR` has the form
+`func(x, y, t, parameters)`.
+
+If `discrete_form = true`, surface_PAR is assumed to have the "discrete form",
+```
+condition(i, j, grid, clock, fields)
+```
+where `i`, and `j` are indices that vary along the boundary. If `discrete_form = true` and
+`parameters` is not `nothing`, the function `condition` is called with
+```
+condition(i, j, grid, clock, fields, parameters)
+```
+
 
 """
 function MultiBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT}, 
@@ -105,6 +118,9 @@ function MultiBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
 
     total_PAR = sum(fields)
 
+    surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, nothing) 
+    surface_PAR = regularize_boundary_condition(surface_PAR, grid, (Center(), Center(), Center()), 3, RightBoundary, nothing)
+
     return MultiBandPhotosyntheticallyActiveRadiation(total_PAR,
                                                       fields, 
                                                       tuple(field_names...), 
@@ -126,14 +142,12 @@ end
 @inline number_subscript(digits::NTuple{N}) where N =
     ntuple(n->Symbol(Char('\xe2\x82\x80'+digits[n])), Val(N))
 
-@kernel function update_MultiBandPhotosyntheticallyActiveRadiation!(grid, field, kʷ, e, χ,
+@kernel function update_MultiBandPhotosyntheticallyActiveRadiation!(grid, clock, field, kʷ, e, χ,
                                                                     _surface_PAR, surface_PAR_division, 
-                                                                    Chl, t, k′) 
+                                                                    Chl, k′) 
     i, j = @index(Global, NTuple)
 
-    X = z_boundary_node(i, j, k′, grid, Center(), Center())
-
-    surface_PAR = _surface_PAR(X..., t)
+    surface_PAR = getbc(_surface_PAR, i, j, grid, clock, P)
 
     zᶜ = znodes(grid, Center(), Center(), Center())
 
@@ -157,7 +171,7 @@ function update_biogeochemical_state!(model, PAR::MultiBandPhotosyntheticallyAct
 
     for (n, field) in enumerate(PAR.fields)
         launch!(arch, grid, :xy, 
-                update_MultiBandPhotosyntheticallyActiveRadiation!, grid, 
+                update_MultiBandPhotosyntheticallyActiveRadiation!, grid, model.clock,
                 field,
                 PAR.water_attenuation_coefficient[n], 
                 PAR.chlorophyll_exponent[n], 
@@ -165,7 +179,6 @@ function update_biogeochemical_state!(model, PAR::MultiBandPhotosyntheticallyAct
                 PAR.surface_PAR, 
                 PAR.surface_PAR_division[n], 
                 chlorophyll(model.biogeochemistry, model), 
-                model.clock.time,
                 k′)
     end
 

--- a/src/Light/multi_band.jl
+++ b/src/Light/multi_band.jl
@@ -119,6 +119,7 @@ function MultiBandPhotosyntheticallyActiveRadiation(; grid::AbstractGrid{FT},
 
     total_PAR = sum(fields)
 
+    # wrap surface_PAR to make it work with the `getbc` interface
     surface_PAR = materialize_condition(surface_PAR, parameters, discrete_form, ()) 
     surface_PAR = regularize_boundary_condition(surface_PAR, grid, (Center(), Center(), Center()), 3, RightBoundary, nothing)
 
@@ -151,9 +152,8 @@ end
 
     zᶜ = znodes(grid, Center(), Center(), Center())
 
-    # first point below surface
     k = grid.Nz
-    @inbounds field[i, j, k] = surface_PAR * surface_PAR_division * exp(zᶜ[grid.Nz] * (kʷ + χ * Chl[i, j, k] ^ e))
+    @inbounds field[i, j, k] = surface_PAR * surface_PAR_division * exp(zᶜ[k] * (kʷ + χ * Chl[i, j, k] ^ e))
 
     # the rest of the points
     for k in grid.Nz-1:-1:1

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -9,10 +9,14 @@ using Oceananigans.Biogeochemistry: update_biogeochemical_state!, required_bioge
 
 Pᵢ(x,y,z) = 2.5 + z
 
-function test_two_band(grid, bgc, model_type)
-    biogeochemistry = bgc(; grid,
-                            light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(; grid),
-                            surface_photosynthetically_active_radiation = (x, y, t) -> 100.0)
+function test_two_band(grid, model_type, surface_PAR, discrete_form)
+    biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(; 
+                        grid,
+                        light_attenuation = 
+                            TwoBandPhotosyntheticallyActiveRadiation(; grid,
+                                                                       surface_PAR, 
+                                                                       discrete_form)
+                      )
 
     model = model_type(grid;
                        biogeochemistry,
@@ -47,17 +51,16 @@ function test_two_band(grid, bgc, model_type)
     return nothing
 end
 
-function test_multi_band(grid, bgc, model_type)
+function test_multi_band(grid, model_type, surface_PAR, discrete_form)
     light_attenuation = MultiBandPhotosyntheticallyActiveRadiation(; grid,
                                                                      bands = ((1, 2), ),
                                                                      base_bands = [1, 2],
                                                                      base_water_attenuation_coefficient = [0.01, 0.01],
                                                                      base_chlorophyll_exponent = [2, 2],
                                                                      base_chlorophyll_attenuation_coefficient = [0.1, 0.1],
-                                                                     surface_PAR = (args...) -> 1)
+                                                                     surface_PAR, discrete_form)
 
-    biogeochemistry = bgc(; grid,
-                            light_attenuation)
+    biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(; grid, light_attenuation)
 
     model = model_type(grid;
                        biogeochemistry,
@@ -66,7 +69,7 @@ function test_multi_band(grid, bgc, model_type)
 
     set!(model, P = 2/1.31) # this will cause tests to fail for models with different chlorophyll ratios
 
-    expected_PAR = on_architecture(CPU(), exp.(znodes(grid, Center()) * (0.01 + 0.1 * 2 ^ 2)))
+    expected_PAR = on_architecture(CPU(), 100 .* exp.(znodes(grid, Center()) * (0.01 + 0.1 * 2 ^ 2)))
 
     @test (@allowscalar all(interior(on_architecture(CPU(), light_attenuation.fields[1]), 1, 1, :) .≈ expected_PAR))
 
@@ -76,10 +79,10 @@ function test_multi_band(grid, bgc, model_type)
                                                                      base_water_attenuation_coefficient = [0.01, 0.01, 0.02, 0.02],
                                                                      base_chlorophyll_exponent = [2, 2, 1.5, 1.5],
                                                                      base_chlorophyll_attenuation_coefficient = [0.1, 0.1, 0.2, 0.2],
-                                                                     surface_PAR = (args...) -> 1)
+                                                                     surface_PAR,
+                                                                     discrete_form)
 
-    biogeochemistry = bgc(; grid,
-                            light_attenuation)
+    biogeochemistry = NutrientPhytoplanktonZooplanktonDetritus(; grid, light_attenuation)
 
     model = model_type(grid;
                        biogeochemistry,
@@ -88,14 +91,15 @@ function test_multi_band(grid, bgc, model_type)
 
     set!(model, P = 2/1.31) # this will cause tests to fail for models with different chlorophyll ratios (e.g. PISCES)
 
-    expected_PAR1 = on_architecture(CPU(), exp.(znodes(grid, Center()) * (0.01 + 0.1 * 2 ^ 2)) / 2)
-    expected_PAR2 = on_architecture(CPU(), exp.(znodes(grid, Center()) * (0.02 + 0.2 * 2 ^ 1.5)) / 2)
+    expected_PAR1 = on_architecture(CPU(), 100 .* exp.(znodes(grid, Center()) * (0.01 + 0.1 * 2 ^ 2)) / 2)
+    expected_PAR2 = on_architecture(CPU(), 100 .* exp.(znodes(grid, Center()) * (0.02 + 0.2 * 2 ^ 1.5)) / 2)
 
     PAR, PAR₁, PAR₂ = map(v-> on_architecture(CPU(), v), values(biogeochemical_auxiliary_fields(light_attenuation)))
 
-    @test all(interior(PAR₁, 1, 1, :) .≈ expected_PAR1)
-    @test all(interior(PAR₂, 1, 1, :) .≈ expected_PAR2)
-    @test all(PAR[1, 1, 1:grid.Nz]  .≈ expected_PAR1 .+ expected_PAR2) # binary operation so we can't `interior` it
+    # not sure why I've had to reduce the tolerances here
+    @test all(isapprox.(interior(PAR₁, 1, 1, :), expected_PAR1, atol=1e-4))
+    @test all(isapprox.(interior(PAR₂, 1, 1, :), expected_PAR2, atol=1e-4))
+    @test  all(isapprox.(PAR[1, 1, 1:grid.Nz], expected_PAR1 .+ expected_PAR2, atol=1e-3)) # binary operation so we can't `interior` it
 
     # check all the models work as expected
     @test isnothing(time_step!(model, 1))
@@ -103,17 +107,31 @@ function test_multi_band(grid, bgc, model_type)
     return nothing
 end
 
+@inline discrete_surface_PAR(i, j, grid, clock, fields) = 100
+@inline continuous_surface_PAR(x, y, t) = 100
+field_surface_PAR = Oceananigans.Fields.ConstantField(100)
+
 @testset "Light attenuaiton model" begin
+
+
     for model in (NonhydrostaticModel, HydrostaticFreeSurfaceModel),
         grid in (RectilinearGrid(architecture; size = (2, 2, 2), extent = (2, 2, 2)),
-                 LatitudeLongitudeGrid(architecture; size = (5, 5, 2), longitude = (-180, 180), latitude = (-85, 85), z = (-2, 0))),
-        bgc in (LOBSTER, NutrientPhytoplanktonZooplanktonDetritus) # this is now redundant since each model doesn't deal with the light separatly
+                 LatitudeLongitudeGrid(architecture; size = (5, 5, 2), longitude = (-180, 180), latitude = (-85, 85), z = (-2, 0)))
 
         if !((model == NonhydrostaticModel) && ((grid isa LatitudeLongitudeGrid) | (grid isa OrthogonalSphericalShellGrid)))
-            @info "Testing light with $bgc in $model on $grid..."
-            test_two_band(grid, bgc, model)
-            test_multi_band(grid, bgc, model)
+            @info "Testing light with in $model on $grid..."
+            test_two_band(grid, model, field_surface_PAR, false)
+            test_multi_band(grid, model, field_surface_PAR, discrete_form)
         end
+    end
+
+    grid = RectilinearGrid(architecture; size = (2, 2, 2), extent = (2, 2, 2))
+
+    for surface_PAR in (discrete_surface_PAR, continuous_surface_PAR, field_surface_PAR)
+        discrete_form = surface_PAR == discrete_surface_PAR
+
+        test_two_band(grid, NonhydrostaticModel, surface_PAR, discrete_form)
+        test_multi_band(grid, NonhydrostaticModel, surface_PAR, discrete_form)
     end
 end
 

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -112,8 +112,6 @@ end
 field_surface_PAR = Oceananigans.Fields.ConstantField(100)
 
 @testset "Light attenuaiton model" begin
-
-
     for model in (NonhydrostaticModel, HydrostaticFreeSurfaceModel),
         grid in (RectilinearGrid(architecture; size = (2, 2, 2), extent = (2, 2, 2)),
                  LatitudeLongitudeGrid(architecture; size = (5, 5, 2), longitude = (-180, 180), latitude = (-85, 85), z = (-2, 0)))
@@ -121,7 +119,7 @@ field_surface_PAR = Oceananigans.Fields.ConstantField(100)
         if !((model == NonhydrostaticModel) && ((grid isa LatitudeLongitudeGrid) | (grid isa OrthogonalSphericalShellGrid)))
             @info "Testing light with in $model on $grid..."
             test_two_band(grid, model, field_surface_PAR, false)
-            test_multi_band(grid, model, field_surface_PAR, discrete_form)
+            test_multi_band(grid, model, field_surface_PAR, false)
         end
     end
 


### PR DESCRIPTION
This PR finally changes the light attenuation models to allow the surface PAR to be continuous or discrete functions, or arrays, or a number, using the `getbc` interface.