### PR TITLE
Generalises carbon chemistry to allow multiple instances

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,6 +71,7 @@ steps:
                 - "eady"
                 - "kelp"
                 - "data_assimilation"
+                - "oae_experiment"
           depends_on: "init"
           agents:
             hostname: "$BUILDKITE_AGENT_META_DATA_HOSTNAME"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OceanBioME"
 uuid = "a49af516-9db8-4be4-be45-1dad61c5a376"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Jago Strong-Wright <js2430@damtp.cam.ac.uk> and contributors"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,8 @@ examples = [
     "Simple column model" => "column",
     "Baroclinic instability" => "eady",
     "Model with particles (kelp) interacting with the biogeochemistry" => "kelp",
-    "Data assimilation" => "data_assimilation"
+    "Data assimilation" => "data_assimilation",
+    "Ocean alkalinity enhancement" => "oae_experiment"
 ]
 
 example_pages = [ title => "generated/$(filename).md" for (title, filename) in examples ]

--- a/examples/column.jl
+++ b/examples/column.jl
@@ -87,18 +87,7 @@ simulation.output_writers[:profiles] = JLD2Writer(model, model.tracers,
                                                   schedule = TimeInterval(1day),
                                                   overwrite_existing = true)
 
-# Also output the surface CO₂ flux
-@inline qCO₂_kernel(i, j, k, grid, clock, DIC, Alk, T, S, carbon_boundary_condition) =
-    carbon_boundary_condition.condition.func(i, j, grid, clock, (; DIC, Alk, T, S))
-
-qCO₂ = KernelFunctionOperation{Center, Center, Face}(qCO₂_kernel,
-                                                     grid,
-                                                     clock,
-                                                     model.tracers.DIC,
-                                                     model.tracers.Alk,
-                                                     model.auxiliary_fields.T,
-                                                     model.auxiliary_fields.S,
-                                                     CO₂_flux)
+qCO₂ = BoundaryConditionOperation(model.tracers.DIC, :top, model)
 
 simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂),
                                                      indices = (:, :, grid.Nz),

--- a/examples/column.jl
+++ b/examples/column.jl
@@ -162,7 +162,7 @@ CO₂_molar_mass = (12 + 2 * 16) * 1e-3 # kg / mol
 
 axfDIC = Axis(fig[5, 1], xlabel = "Time (days)", ylabel = "Flux (kgCO₂/m²/year)",
                          title = "Air-sea CO₂ flux and Sinking", limits = ((0, times[end] / days), nothing))
-lines!(axfDIC, times / days, air_sea_CO₂_flux[1, 1, grid.Nz, :] / 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
+lines!(axfDIC, times / days, interior(air_sea_CO₂_flux, 1, 1, grid.Nz, :) ./ 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
 lines!(axfDIC, times / days, carbon_export / 1e3    * CO₂_molar_mass * year, linewidth = 3, label = "Sinking export")
 Legend(fig[5, 2], axfDIC, framevisible = false)
 

--- a/examples/column.jl
+++ b/examples/column.jl
@@ -162,7 +162,7 @@ CO₂_molar_mass = (12 + 2 * 16) * 1e-3 # kg / mol
 
 axfDIC = Axis(fig[5, 1], xlabel = "Time (days)", ylabel = "Flux (kgCO₂/m²/year)",
                          title = "Air-sea CO₂ flux and Sinking", limits = ((0, times[end] / days), nothing))
-lines!(axfDIC, times / days, interior(air_sea_CO₂_flux, 1, 1, grid.Nz, :) ./ 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
+lines!(axfDIC, times / days, interior(air_sea_CO₂_flux, 1, 1, 1, :) ./ 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
 lines!(axfDIC, times / days, carbon_export / 1e3    * CO₂_molar_mass * year, linewidth = 3, label = "Sinking export")
 Legend(fig[5, 2], axfDIC, framevisible = false)
 

--- a/examples/data_forced.jl
+++ b/examples/data_forced.jl
@@ -121,6 +121,14 @@ simulation.output_writers[:profiles] = JLD2Writer(model,
                                                   schedule = TimeInterval(1day),
                                                   overwrite_existing = true)
 
+qCO₂ = BoundaryConditionOperation(model.tracers.DIC, :top, model)
+
+simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂),
+                                                     indices = (:, :, grid.Nz),
+                                                     filename = filename * "_carbon.jld2",
+                                                     schedule = TimeInterval(1day),
+                                                     overwrite_existing = true)
+
 wizard = TimeStepWizard(cfl = 0.2, diffusive_cfl = 0.2,
                         max_change = 1.5, min_change = 0.75,
                         cell_advection_timescale = column_advection_timescale)
@@ -141,24 +149,22 @@ run!(simulation)
 sPOM = FieldTimeSeries("$filename.jld2", "sPOM")
 bPOM = FieldTimeSeries("$filename.jld2", "bPOM")
  DIC = FieldTimeSeries("$filename.jld2", "DIC")
- Alk = FieldTimeSeries("$filename.jld2", "Alk")
+ Alk = FieldTimeSeries("$filename.jld2", "Alk") 
+ 
+air_sea_CO₂_flux = mean(interior(FieldTimeSeries(filename * "_carbon.jld2", "qCO₂")), dims = (1, 2))[1, 1, 1, :]
 
 x, y, z = nodes(P)
 times = P.times
 nothing #hide
 
-# We compute the  air-sea CO₂ flux at the surface (corresponding to vertical index `k = grid.Nz`) and
-# the carbon export by computing how much carbon sinks below some arbitrary depth; here we use depth
-# that corresponds to `k = grid.Nz - 20`.
-air_sea_CO₂_flux = zeros(length(times))
+# We compute the carbon export by computing how much carbon sinks below some arbitrary depth; 
+# here we use depth that corresponds to `k = grid.Nz - 20`.
 carbon_export = zeros(length(times))
 
 using Oceananigans.Biogeochemistry: biogeochemical_drift_velocity
 
 for (n, t) in enumerate(times)
     clock.time = t
-
-    air_sea_CO₂_flux[n] = CO₂_flux.condition.func(1, 1, grid, clock, (; DIC = DIC[n], Alk = Alk[n], T, S))
 
     carbon_export[n] = (sPOM[n][1, 1, grid.Nz-20] * biogeochemical_drift_velocity(model.biogeochemistry, Val(:sPOM)).w[1, 1, grid.Nz-20] +
                         bPOM[n][1, 1, grid.Nz-20] * biogeochemical_drift_velocity(model.biogeochemistry, Val(:bPOM)).w[1, 1, grid.Nz-20]) * redfield(Val(:sPOM), model.biogeochemistry)

--- a/examples/eady.jl
+++ b/examples/eady.jl
@@ -22,9 +22,9 @@ using Oceananigans.Units
 using Random
 Random.seed!(11)
 
-# Construct a grid with uniform grid spacing on GPU (just remove `GPU()` to run on CPU)
-grid = RectilinearGrid(CPU();#GPU();
- size = (32, 32, 8), extent = (1kilometer, 1kilometer, 100meters))
+# Construct a grid with uniform grid spacing on CPU 
+grid = RectilinearGrid(size = (32, 32, 8), 
+                       extent = (1kilometer, 1kilometer, 100meters))
 
 # Set the Coriolis and buoyancy models.
 coriolis = FPlane(f = 1e-4) # [s⁻¹]

--- a/examples/kelp.jl
+++ b/examples/kelp.jl
@@ -171,7 +171,7 @@ CO₂_molar_mass = (12 + 2 * 16) * 1e-3 # kg / mol
 
 axfDIC = Axis(fig[4, 1], xlabel = "Time (days)", ylabel = "Flux (kgCO₂/m²/year)",
                          title = "Air-sea CO₂ flux and Sinking", limits = ((0, times[end] / days), nothing))
-lines!(axfDIC, times / days, air_sea_CO₂_flux[1, 1, grid.Nz, :] / 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
+lines!(axfDIC, times / days, interior(air_sea_CO₂_flux, 1, 1, grid.Nz, :) ./ 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
 lines!(axfDIC, times / days, carbon_export / 1e3 * CO₂_molar_mass * year, linewidth = 3, label = "Sinking export")
 Legend(fig[4, 2], axfDIC, framevisible = false)
 

--- a/examples/kelp.jl
+++ b/examples/kelp.jl
@@ -171,7 +171,7 @@ CO₂_molar_mass = (12 + 2 * 16) * 1e-3 # kg / mol
 
 axfDIC = Axis(fig[4, 1], xlabel = "Time (days)", ylabel = "Flux (kgCO₂/m²/year)",
                          title = "Air-sea CO₂ flux and Sinking", limits = ((0, times[end] / days), nothing))
-lines!(axfDIC, times / days, interior(air_sea_CO₂_flux, 1, 1, grid.Nz, :) ./ 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
+lines!(axfDIC, times / days, interior(air_sea_CO₂_flux, 1, 1, 1, :) ./ 1e3 * CO₂_molar_mass * year * 10, linewidth = 3, label = "Air-sea flux x10")
 lines!(axfDIC, times / days, carbon_export / 1e3 * CO₂_molar_mass * year, linewidth = 3, label = "Sinking export")
 Legend(fig[4, 2], axfDIC, framevisible = false)
 

--- a/examples/kelp.jl
+++ b/examples/kelp.jl
@@ -111,18 +111,7 @@ simulation.output_writers[:particles] = JLD2Writer(model, (; particles),
                                                    schedule = TimeInterval(1day),
                                                    overwrite_existing = true)
 
-# Also output the surface CO₂ flux
-@inline qCO₂_kernel(i, j, k, grid, clock, DIC, Alk, T, S, carbon_boundary_condition) =
-    carbon_boundary_condition.condition.func(i, j, grid, clock, (; DIC, Alk, T, S))
-
-qCO₂ = KernelFunctionOperation{Center, Center, Face}(qCO₂_kernel,
-                                                     grid,
-                                                     clock,
-                                                     model.tracers.DIC,
-                                                     model.tracers.Alk,
-                                                     model.auxiliary_fields.T,
-                                                     model.auxiliary_fields.S,
-                                                     CO₂_flux)
+qCO₂ = BoundaryConditionOperation(model.tracers.DIC, :top, model)
 
 simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂),
                                                      indices = (:, :, grid.Nz),

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -1,0 +1,140 @@
+# # Idealised ocean alkalinity enhancement (OAE)
+#
+# In this example we setup a 3D model driven by a constant wind stress, with 2 instances
+# of the carbon chemistry system (DIC and alkalinity). We then add alkalinity to one of
+# the instances replicating an OAE release, and compare to the unperturbed counterfactual
+
+# ## Install dependencies
+# First we ensure we have the required dependencies installed
+# ```julia
+# using Pkg
+# pkg "add OceanBioME, Oceananigans, CairoMakie"
+# ```
+
+# ## Model setup
+
+using Oceananigans, OceanBioME, Oceananigans.Units
+
+using OceanBioME.Models.GasExchangeModel: CarbonDioxideConcentration
+
+grid = RectilinearGrid(CPU(); 
+                       size = (64, 64, 8), 
+                       extent = (500, 500, 15))
+
+biogeochemistry = LOBSTER(grid;
+                          carbonate_system = CarbonateSystem(2))
+
+carbon_chemistry = CarbonChemistry()
+CO₂_flux1 = CarbonDioxideGasExchangeBoundaryCondition(; water_concentration = 
+                                                            CarbonDioxideConcentration(; carbon_chemistry, 
+                                                                                         DIC = :DIC1,
+                                                                                         Alk = :Alk1))
+CO₂_flux2 = CarbonDioxideGasExchangeBoundaryCondition(; water_concentration = 
+                                                            CarbonDioxideConcentration(; carbon_chemistry, 
+                                                                                         DIC = :DIC2,
+                                                                                         Alk = :Alk2))
+wind = FluxBoundaryCondition(-1.2/1026*2e-3*10^2)
+
+boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
+                         DIC2 = FieldBoundaryConditions(top = CO₂_flux2),
+                         u    = FieldBoundaryConditions(top = wind))
+
+@inline oae_release(x, y, z, t, params) = 
+    ifelse((params.tstart <= t <= params.tend) & (z > params.release_depth) & ((x-250)^2 + (y-250)^2 < params.radius^2), params.release_rate, 0)
+
+oae = Forcing(oae_release; parameters = (; tstart = 1hour, tend = 2hour, release_rate = 1/hour, release_depth = -1, radius = 50)) 
+# release rate should probably be replaced by a release quantity that is appropriatly turned into a concentration
+
+model = NonhydrostaticModel(grid;
+                            coriolis = FPlane(latitude = 45),
+                            boundary_conditions,
+                            biogeochemistry,
+                            advection = WENO(),
+                            tracers = (:T, :S),
+                            forcing = (; Alk2 = oae))
+
+set!(model, P = 1, NO₃ = 10, T = 15, S = 35, DIC1 = 1035.5, Alk1 = 1100.065, DIC2 = 1035.5, Alk2 = 1100.065, u = (x, y, z) -> randn()/2)
+
+simulation = Simulation(model, Δt = 5, stop_time = 1day)
+
+conjure_time_step_wizard!(simulation)
+
+prog(sim) = @info prettytime(sim) * " in " * prettytime(sim.run_wall_time) * " with Δt = " * prettytime(sim.Δt)
+
+add_callback!(simulation, prog, IterationInterval(100))
+
+simulation.output_writers[:tracers] = JLD2Writer(model, model.tracers;
+                                                filename = "oae.jld2",
+                                                schedule = AveragedTimeInterval(5minutes),
+                                                overwrite_existing = true)
+
+qCO₂1 = BoundaryConditionOperation(model.tracers.DIC1, :top, model)
+qCO₂2 = BoundaryConditionOperation(model.tracers.DIC2, :top, model)
+
+
+simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂1, qCO₂2),
+                                                     indices = (:, :, grid.Nz),
+                                                     filename = "oae_surface_flux.jld2",
+                                                     schedule = TimeInterval(5minutes),
+                                                     overwrite_existing = true)
+
+run!(simulation)
+
+using CairoMakie
+
+fds = FieldDataset("oae.jld2")
+fds_surface = FieldDataset("oae_surface_flux.jld2")
+
+n = Observable(1)
+
+N = length(fds["P"])
+
+P_plt = @lift view(fds["P"][$n], :, :, grid.Nz)
+Δ_Alk = @lift interior(fds["Alk2"][$n], :, :, grid.Nz) .- interior(fds["Alk1"][$n], :, :, grid.Nz)
+Δ_qCO₂ = @lift (interior(fds_surface["qCO₂2"][$n], :, :, 1) .- interior(fds_surface["qCO₂1"][$n], :, :, 1)) .* (12+2*16)*1e-3*day
+Δ_DIC = @lift interior(fds["DIC2"][$n], :, :, Alk1.grid.Nz) .- interior(fds["DIC1"][$n], :, :, Alk1.grid.Nz)
+
+P_range = (minimum(fds["P"]), maximum(fds["P"]))
+Δ_Alk_range = maximum(map(n->maximum(abs, fds["Alk2"][n] - fds["Alk1"][n]), 1:N))
+Δ_qCO₂_range = maximum(map(n->maximum(abs, fds_surface["qCO₂2"][n] -fds_surface["qCO₂1"][n]), 1:N) .* (12+2*16)*1e-3*day)
+Δ_DIC_range = maximum(map(n->maximum(abs, fds["DIC2"][n] - fds["DIC1"][n]), 1:N))
+
+xc = xnodes(fds["P"])
+yc = ynodes(fds["P"])
+
+fig = Figure(size=(1000, 1150))
+
+ax = Axis(fig[2, 1], aspect = DataAspect())
+ax2 = Axis(fig[2, 2], aspect = DataAspect())
+ax3 = Axis(fig[4, 1], aspect = DataAspect())
+ax4 = Axis(fig[4, 2], aspect = DataAspect())
+
+hm1 = heatmap!(ax, P_plt, colorrange = P_range)
+hm2 = heatmap!(ax2, xc, yc, Δ_Alk, colormap = :balance, colorrange = (-1, 1) .* Δ_Alk_range)
+hm3 = heatmap!(ax3, xc, yc, Δ_qCO₂, colormap = :balance, colorrange = (-1, 1) .* Δ_qCO₂_range)
+hm4 = heatmap!(ax4, xc, yc, Δ_DIC, colormap = :balance, colorrange = (-1, 1) .* Δ_DIC_range)
+
+Colorbar(fig[1, 1], hm1, vertical = false, label = "Phytoplankton (mmol N/m³)")
+Colorbar(fig[1, 2], hm2, vertical = false, label = "Alkalinity pertubation (mmol / m³)")
+Colorbar(fig[3, 1], hm3, vertical = false, label = "Surface CO₂ flux difference (gCO₂/m²/day)")
+Colorbar(fig[3, 2], hm4, vertical = false, label = "DIC pertubation (mmol C / m³)")
+
+supertitle = Label(fig[0, :], (@lift prettytime(fds["P"].times[$n])))
+
+CairoMakie.record(fig, "oae.mp4", 1:N, framerate=10) do i
+    @info "$i"
+    n[] = i
+end
+
+fig = Figure()
+
+ax = Axis(fig[1, 1], ylabel = "Surface CO₂ flux (gCO₂/m²/day)")
+
+lines!(ax, fds_surface["qCO₂1"].times./day, map(n->mean(interior(fds_surface["qCO₂1"][n], :, :, 1)).* (12+2*16)*1e-3*day, 1:N))
+lines!(ax, fds_surface["qCO₂2"].times./day, map(n->mean(interior(fds_surface["qCO₂2"][n], :, :, 1)).* (12+2*16)*1e-3*day, 1:N))
+
+ax2 = Axis(fig[2, 1], xlabel = "Time (hours)", ylabel = "Cumulative CO₂ flux difference (gCO₂/m²)")
+
+Δt = diff(fds_surface["qCO₂1"].times./day)[1]
+
+lines!(ax2, fds_surface["qCO₂1"].times./day, Δt .* cumsum(map(n->(mean(interior(fds_surface["qCO₂2"][n], :, :, 1)) - mean(interior(fds_surface["qCO₂1"][n], :, :, 1))).* (12+2*16)*1e-3*day, 1:N)))

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -56,7 +56,7 @@ depth = -1
 radius = 50
 release_rate = total_release/duration/(π*radius^2*abs(depth))
 
-oae = Forcing(oae_release; parameters = (; start_time = 1hour, 
+oae = Forcing(oae_release; parameters = (; start_time = 20minutes, 
                                            duration, 
                                            release_rate, 
                                            radius, 
@@ -76,7 +76,7 @@ set!(model, P = 1, NO₃ = 10,
             DIC2 = 2000, Alk2 = 2300, 
             u = (x, y, z) -> randn()/2)
 
-simulation = Simulation(model, Δt = 5, stop_time = 5hours)
+simulation = Simulation(model, Δt = 5, stop_time = 2hours)
 
 conjure_time_step_wizard!(simulation)
 

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -25,14 +25,19 @@ biogeochemistry = LOBSTER(grid;
                           carbonate_system = CarbonateSystem(2))
 
 carbon_chemistry = CarbonChemistry()
-CO₂_flux1 = CarbonDioxideGasExchangeBoundaryCondition(; water_concentration = 
-                                                            CarbonDioxideConcentration(; carbon_chemistry, 
-                                                                                         DIC = :DIC1,
-                                                                                         Alk = :Alk1))
-CO₂_flux2 = CarbonDioxideGasExchangeBoundaryCondition(; water_concentration = 
-                                                            CarbonDioxideConcentration(; carbon_chemistry, 
-                                                                                         DIC = :DIC2,
-                                                                                         Alk = :Alk2))
+CO₂_flux1 = 
+    CarbonDioxideGasExchangeBoundaryCondition(; 
+        water_concentration = CarbonDioxideConcentration(; carbon_chemistry, 
+                                                            DIC = :DIC1,
+                                                            Alk = :Alk1)
+    )
+CO₂_flux2 = 
+    CarbonDioxideGasExchangeBoundaryCondition(; 
+        water_concentration = CarbonDioxideConcentration(; carbon_chemistry, 
+                                                            DIC = :DIC2,
+                                                            Alk = :Alk2)
+    )
+
 wind = FluxBoundaryCondition(-1.2/1026*2e-3*10^2)
 
 boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
@@ -40,7 +45,10 @@ boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
                          u    = FieldBoundaryConditions(top = wind))
 
 @inline oae_release(x, y, z, t, params) = 
-    ifelse((params.start_time <= t < params.start_time + params.duration) & (z > params.depth) & ((x-250)^2 + (y-250)^2 < params.radius^2), params.release_rate, 0)
+    ifelse((params.start_time <= t < params.start_time + params.duration) & 
+            (z > params.depth) & 
+            ((x-250)^2 + (y-250)^2 < params.radius^2), 
+            params.release_rate, 0)
 
 total_release = 2.5e7 # 1t NaOH = 25000mol NaOH = 2.5e7 meq Alk
 duration = 1hour
@@ -48,7 +56,11 @@ depth = -1
 radius = 50
 release_rate = total_release/duration/(π*radius^2*abs(depth))
 
-oae = Forcing(oae_release; parameters = (; start_time = 1hour, duration, release_rate, radius, depth)) 
+oae = Forcing(oae_release; parameters = (; start_time = 1hour, 
+                                           duration, 
+                                           release_rate, 
+                                           radius, 
+                                           depth)) 
 
 model = NonhydrostaticModel(grid;
                             coriolis = FPlane(latitude = 45),
@@ -58,13 +70,18 @@ model = NonhydrostaticModel(grid;
                             tracers = (:T, :S),
                             forcing = (; Alk2 = oae))
 
-set!(model, P = 1, NO₃ = 10, T = 15, S = 35, DIC1 = 2000, Alk1 = 2300, DIC2 = 2000, Alk2 = 2300, u = (x, y, z) -> randn()/2)
+set!(model, P = 1, NO₃ = 10, 
+            T = 15, S = 35,
+            DIC1 = 2000, Alk1 = 2300, 
+            DIC2 = 2000, Alk2 = 2300, 
+            u = (x, y, z) -> randn()/2)
 
 simulation = Simulation(model, Δt = 5, stop_time = 5hours)
 
 conjure_time_step_wizard!(simulation)
 
-prog(sim) = @info prettytime(sim) * " in " * prettytime(sim.run_wall_time) * " with Δt = " * prettytime(sim.Δt)
+prog(sim) = 
+    @info prettytime(sim)*" in "*prettytime(sim.run_wall_time)*" with Δt = "*prettytime(sim.Δt)
 
 add_callback!(simulation, prog, IterationInterval(100))
 
@@ -94,11 +111,15 @@ n = Observable(1)
 
 N = length(fds["P"])
 
-Δ_Alk = @lift (mean(interior(fds["Alk2"][$n]), dims=3)[:, :, 1] .- mean(interior(fds["Alk1"][$n]), dims=3)[1, 1, :]).* 15
-Δ_qCO₂ = @lift (interior(fds_surface["qCO₂2"][$n], :, :, 1) .- interior(fds_surface["qCO₂1"][$n], :, :, 1)) .* (12+2*16)*1e-3*day
+Δ_Alk = @lift (mean(interior(fds["Alk2"][$n]), dims=3)[:, :, 1] .- 
+               mean(interior(fds["Alk1"][$n]), dims=3)[1, 1, :]).* 15
+Δ_qCO₂ = @lift (interior(fds_surface["qCO₂2"][$n], :, :, 1) .- 
+                interior(fds_surface["qCO₂1"][$n], :, :, 1)) .* (12+2*16)*1e-3*day
 
-Δ_Alk_range = maximum(abs, mean(interior(fds["Alk2"]), dims = 3) .- mean(interior(fds["Alk1"]), dims = 3)) .* 15
-Δ_qCO₂_range = maximum(abs, interior(fds_surface["qCO₂2"]) .- interior(fds_surface["qCO₂1"])) .* (12+2*16)*1e-3*day
+Δ_Alk_range = maximum(abs, mean(interior(fds["Alk2"]), dims = 3) .- 
+                           mean(interior(fds["Alk1"]), dims = 3)) .* 15
+Δ_qCO₂_range = maximum(abs, interior(fds_surface["qCO₂2"]) .- 
+                            interior(fds_surface["qCO₂1"])) .* (12+2*16)*1e-3*day
 
 xc = xnodes(fds["P"])
 yc = ynodes(fds["P"])
@@ -111,8 +132,12 @@ ax2 = Axis(fig[1, 2], aspect = DataAspect())
 hm = heatmap!(ax, xc, yc, Δ_Alk, colormap = :balance, colorrange = (-1, 1) .* Δ_Alk_range)
 hm2 = heatmap!(ax2, xc, yc, Δ_qCO₂, colormap = :balance, colorrange = (-1, 1) .* Δ_qCO₂_range)
 
-Colorbar(fig[2, 1], hm, vertical = false, label = "Alkalinity pertubation (mmol / m³)", flip_vertical_label = true)
-Colorbar(fig[2, 2], hm2, vertical = false, label = "Surface CO₂ flux difference (gCO₂/m²/day)", flip_vertical_label = true)
+Colorbar(fig[2, 1], hm, vertical = false, 
+                        label = "Alkalinity pertubation (mmol / m³)", 
+                        flip_vertical_label = true)
+Colorbar(fig[2, 2], hm2, vertical = false, 
+                         label = "Surface CO₂ flux difference (gCO₂/m²/day)", 
+                         flip_vertical_label = true)
 
 supertitle = Label(fig[0, :], (@lift prettytime(fds["P"].times[$n])))
 
@@ -130,14 +155,18 @@ ax = Axis(fig[1, 1], title = "Surface flux (gC/day)")
 surface_area = 500*500
 mmol_to_g = 12/1000
 
-lines!(ax, fds_surface["qCO₂1"].times./hours, mean(interior(fds_surface["qCO₂1"], :, :, 1, :), dims = (1, 2))[1, 1, :].* mmol_to_g * surface_area * day)
-lines!(ax, fds_surface["qCO₂2"].times./hours, mean(interior(fds_surface["qCO₂2"], :, :, 1, :), dims = (1, 2))[1, 1, :].* mmol_to_g * surface_area * day)
+total_carbon_flux1 =  mean(interior(fds_surface["qCO₂1"], :, :, 1, :), dims = (1, 2))[1, 1, :]
+total_carbon_flux2 =  mean(interior(fds_surface["qCO₂2"], :, :, 1, :), dims = (1, 2))[1, 1, :]
+
+lines!(ax, fds_surface["qCO₂1"].times./hours, total_carbon_flux1 .* mmol_to_g * surface_area * day)
+lines!(ax, fds_surface["qCO₂2"].times./hours, total_carbon_flux2 .* mmol_to_g * surface_area * day)
 
 ax2 = Axis(fig[2, 1], xlabel = "Time (hours)", title = "Cumulative difference (gC)")
 
 Δt = diff(fds_surface["qCO₂1"].times./hours)[1]
 
-change =  mean(interior(fds_surface["qCO₂1"], :, :, 1, :), dims = (1, 2))[1, 1, :] .- mean(interior(fds_surface["qCO₂2"], :, :, 1, :), dims = (1, 2))[1, 1, :]
+change =  mean(interior(fds_surface["qCO₂1"], :, :, 1, :), dims = (1, 2))[1, 1, :] .- 
+          mean(interior(fds_surface["qCO₂2"], :, :, 1, :), dims = (1, 2))[1, 1, :]
 change .*= mmol_to_g * surface_area
 
 Δt_save = diff(fds_surface["qCO₂1"].times)[1]

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -42,7 +42,7 @@ boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
 @inline oae_release(x, y, z, t, params) = 
     ifelse((params.start_time <= t < params.start_time + params.duration) & (z > params.depth) & ((x-250)^2 + (y-250)^2 < params.radius^2), params.release_rate, 0)
 
-total_release = 2.5e8 # 1t NaOH
+total_release = 2.5e7 # 1t NaOH = 25000mol NaOH = 2.5e7 meq Alk
 duration = 1hour
 depth = -1
 radius = 50
@@ -58,9 +58,9 @@ model = NonhydrostaticModel(grid;
                             tracers = (:T, :S),
                             forcing = (; Alk2 = oae))
 
-set!(model, P = 1, NO₃ = 10, T = 15, S = 35, DIC1 = 1035.5, Alk1 = 1100.065, DIC2 = 1035.5, Alk2 = 1100.065, u = (x, y, z) -> randn()/2)
+set!(model, P = 1, NO₃ = 10, T = 15, S = 35, DIC1 = 2000, Alk1 = 2300, DIC2 = 2000, Alk2 = 2300, u = (x, y, z) -> randn()/2)
 
-simulation = Simulation(model, Δt = 5, stop_time = 1day)
+simulation = Simulation(model, Δt = 5, stop_time = 5hours)
 
 conjure_time_step_wizard!(simulation)
 
@@ -70,7 +70,7 @@ add_callback!(simulation, prog, IterationInterval(100))
 
 simulation.output_writers[:tracers] = JLD2Writer(model, model.tracers;
                                                 filename = "oae.jld2",
-                                                schedule = AveragedTimeInterval(5minutes),
+                                                schedule = AveragedTimeInterval(2minutes),
                                                 overwrite_existing = true)
 
 qCO₂1 = BoundaryConditionOperation(model.tracers.DIC1, :top, model)
@@ -80,7 +80,7 @@ qCO₂2 = BoundaryConditionOperation(model.tracers.DIC2, :top, model)
 simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂1, qCO₂2),
                                                      indices = (:, :, grid.Nz),
                                                      filename = "oae_surface_flux.jld2",
-                                                     schedule = TimeInterval(5minutes),
+                                                     schedule = TimeInterval(2minutes),
                                                      overwrite_existing = true)
 
 run!(simulation)
@@ -94,35 +94,25 @@ n = Observable(1)
 
 N = length(fds["P"])
 
-P_plt = @lift view(fds["P"][$n], :, :, grid.Nz)
-Δ_Alk = @lift interior(fds["Alk2"][$n], :, :, grid.Nz) .- interior(fds["Alk1"][$n], :, :, grid.Nz)
+Δ_Alk = @lift (mean(interior(fds["Alk2"][$n]), dims=3)[:, :, 1] .- mean(interior(fds["Alk1"][$n]), dims=3)[1, 1, :]).* 15
 Δ_qCO₂ = @lift (interior(fds_surface["qCO₂2"][$n], :, :, 1) .- interior(fds_surface["qCO₂1"][$n], :, :, 1)) .* (12+2*16)*1e-3*day
-Δ_DIC = @lift interior(fds["DIC2"][$n], :, :, Alk1.grid.Nz) .- interior(fds["DIC1"][$n], :, :, Alk1.grid.Nz)
 
-P_range = (minimum(fds["P"]), maximum(fds["P"]))
-Δ_Alk_range = maximum(map(n->maximum(abs, fds["Alk2"][n] - fds["Alk1"][n]), 1:N))
-Δ_qCO₂_range = maximum(map(n->maximum(abs, fds_surface["qCO₂2"][n] -fds_surface["qCO₂1"][n]), 1:N) .* (12+2*16)*1e-3*day)
-Δ_DIC_range = maximum(map(n->maximum(abs, fds["DIC2"][n] - fds["DIC1"][n]), 1:N))
+Δ_Alk_range = maximum(abs, mean(interior(fds["Alk2"]), dims = 3) .- mean(interior(fds["Alk1"]), dims = 3)) .* 15
+Δ_qCO₂_range = maximum(abs, interior(fds_surface["qCO₂2"]) .- interior(fds_surface["qCO₂1"])) .* (12+2*16)*1e-3*day
 
 xc = xnodes(fds["P"])
 yc = ynodes(fds["P"])
 
-fig = Figure(size=(1000, 1150))
+fig = Figure(size=(1000, 500))
 
-ax = Axis(fig[2, 1], aspect = DataAspect())
-ax2 = Axis(fig[2, 2], aspect = DataAspect())
-ax3 = Axis(fig[4, 1], aspect = DataAspect())
-ax4 = Axis(fig[4, 2], aspect = DataAspect())
+ax = Axis(fig[1, 1], aspect = DataAspect())
+ax2 = Axis(fig[1, 2], aspect = DataAspect())
 
-hm1 = heatmap!(ax, P_plt, colorrange = P_range)
-hm2 = heatmap!(ax2, xc, yc, Δ_Alk, colormap = :balance, colorrange = (-1, 1) .* Δ_Alk_range)
-hm3 = heatmap!(ax3, xc, yc, Δ_qCO₂, colormap = :balance, colorrange = (-1, 1) .* Δ_qCO₂_range)
-hm4 = heatmap!(ax4, xc, yc, Δ_DIC, colormap = :balance, colorrange = (-1, 1) .* Δ_DIC_range)
+hm = heatmap!(ax, xc, yc, Δ_Alk, colormap = :balance, colorrange = (-1, 1) .* Δ_Alk_range)
+hm2 = heatmap!(ax2, xc, yc, Δ_qCO₂, colormap = :balance, colorrange = (-1, 1) .* Δ_qCO₂_range)
 
-Colorbar(fig[1, 1], hm1, vertical = false, label = "Phytoplankton (mmol N/m³)")
-Colorbar(fig[1, 2], hm2, vertical = false, label = "Alkalinity pertubation (mmol / m³)")
-Colorbar(fig[3, 1], hm3, vertical = false, label = "Surface CO₂ flux difference (gCO₂/m²/day)")
-Colorbar(fig[3, 2], hm4, vertical = false, label = "DIC pertubation (mmol C / m³)")
+Colorbar(fig[2, 1], hm, vertical = false, label = "Alkalinity pertubation (mmol / m³)", flip_vertical_label = true)
+Colorbar(fig[2, 2], hm2, vertical = false, label = "Surface CO₂ flux difference (gCO₂/m²/day)", flip_vertical_label = true)
 
 supertitle = Label(fig[0, :], (@lift prettytime(fds["P"].times[$n])))
 
@@ -131,15 +121,29 @@ CairoMakie.record(fig, "oae.mp4", 1:N, framerate=10) do i
     n[] = i
 end
 
-fig = Figure()
+# ![](oae.mp4)
 
-ax = Axis(fig[1, 1], ylabel = "Surface CO₂ flux (gCO₂/m²/day)")
+fig = Figure();
 
-lines!(ax, fds_surface["qCO₂1"].times./day, map(n->mean(interior(fds_surface["qCO₂1"][n], :, :, 1)).* (12+2*16)*1e-3*day, 1:N))
-lines!(ax, fds_surface["qCO₂2"].times./day, map(n->mean(interior(fds_surface["qCO₂2"][n], :, :, 1)).* (12+2*16)*1e-3*day, 1:N))
+ax = Axis(fig[1, 1], title = "Surface flux (gC/day)")
 
-ax2 = Axis(fig[2, 1], xlabel = "Time (hours)", ylabel = "Cumulative CO₂ flux difference (gCO₂/m²)")
+surface_area = 500*500
+mmol_to_g = 12/1000
 
-Δt = diff(fds_surface["qCO₂1"].times./day)[1]
+lines!(ax, fds_surface["qCO₂1"].times./hours, mean(interior(fds_surface["qCO₂1"], :, :, 1, :), dims = (1, 2))[1, 1, :].* mmol_to_g * surface_area * day)
+lines!(ax, fds_surface["qCO₂2"].times./hours, mean(interior(fds_surface["qCO₂2"], :, :, 1, :), dims = (1, 2))[1, 1, :].* mmol_to_g * surface_area * day)
 
-lines!(ax2, fds_surface["qCO₂1"].times./day, Δt .* cumsum(map(n->(mean(interior(fds_surface["qCO₂2"][n], :, :, 1)) - mean(interior(fds_surface["qCO₂1"][n], :, :, 1))).* (12+2*16)*1e-3*day, 1:N)))
+ax2 = Axis(fig[2, 1], xlabel = "Time (hours)", title = "Cumulative difference (gC)")
+
+Δt = diff(fds_surface["qCO₂1"].times./hours)[1]
+
+change =  mean(interior(fds_surface["qCO₂1"], :, :, 1, :), dims = (1, 2))[1, 1, :] .- mean(interior(fds_surface["qCO₂2"], :, :, 1, :), dims = (1, 2))[1, 1, :]
+change .*= mmol_to_g * surface_area
+
+Δt_save = diff(fds_surface["qCO₂1"].times)[1]
+
+cumulative_change = cumsum(Δt_save .* change)
+
+lines!(ax2, fds_surface["qCO₂1"].times./hours, cumulative_change)
+
+fig

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -17,7 +17,7 @@ using Oceananigans, OceanBioME, Oceananigans.Units
 
 using OceanBioME.Models.GasExchangeModel: CarbonDioxideConcentration
 
-grid = RectilinearGrid(CPU(); 
+grid = RectilinearGrid(GPU(); 
                        size = (64, 64, 8), 
                        extent = (500, 500, 15))
 
@@ -40,10 +40,15 @@ boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
                          u    = FieldBoundaryConditions(top = wind))
 
 @inline oae_release(x, y, z, t, params) = 
-    ifelse((params.tstart <= t <= params.tend) & (z > params.release_depth) & ((x-250)^2 + (y-250)^2 < params.radius^2), params.release_rate, 0)
+    ifelse((params.start_time <= t < params.start_time + params.duration) & (z > params.depth) & ((x-250)^2 + (y-250)^2 < params.radius^2), params.release_rate, 0)
 
-oae = Forcing(oae_release; parameters = (; tstart = 1hour, tend = 2hour, release_rate = 1/hour, release_depth = -1, radius = 50)) 
-# release rate should probably be replaced by a release quantity that is appropriatly turned into a concentration
+total_release = 2.5e8 # 1t NaOH
+duration = 1hour
+depth = -1
+radius = 50
+release_rate = total_release/duration/(π*radius^2*abs(depth))
+
+oae = Forcing(oae_release; parameters = (; start_time = 1hour, duration, release_rate, radius, depth)) 
 
 model = NonhydrostaticModel(grid;
                             coriolis = FPlane(latitude = 45),

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -70,7 +70,7 @@ add_callback!(simulation, prog, IterationInterval(100))
 
 simulation.output_writers[:tracers] = JLD2Writer(model, model.tracers;
                                                 filename = "oae.jld2",
-                                                schedule = AveragedTimeInterval(2minutes),
+                                                schedule = AveragedTimeInterval(5minutes),
                                                 overwrite_existing = true)
 
 qCO₂1 = BoundaryConditionOperation(model.tracers.DIC1, :top, model)
@@ -80,12 +80,12 @@ qCO₂2 = BoundaryConditionOperation(model.tracers.DIC2, :top, model)
 simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂1, qCO₂2),
                                                      indices = (:, :, grid.Nz),
                                                      filename = "oae_surface_flux.jld2",
-                                                     schedule = TimeInterval(2minutes),
+                                                     schedule = TimeInterval(5minutes),
                                                      overwrite_existing = true)
 
 run!(simulation)
 
-using CairoMakie
+using CairoMakie, Statistics
 
 fds = FieldDataset("oae.jld2")
 fds_surface = FieldDataset("oae_surface_flux.jld2")

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -24,18 +24,15 @@ grid = RectilinearGrid(GPU();
 biogeochemistry = LOBSTER(grid;
                           carbonate_system = CarbonateSystem(2))
 
-carbon_chemistry = CarbonChemistry()
 CO₂_flux1 = 
     CarbonDioxideGasExchangeBoundaryCondition(; 
-        water_concentration = CarbonDioxideConcentration(; carbon_chemistry, 
-                                                            DIC = :DIC1,
-                                                            Alk = :Alk1)
+        water_concentration = CarbonDioxideConcentration(; DIC = :DIC1,
+                                                           Alk = :Alk1)
     )
 CO₂_flux2 = 
     CarbonDioxideGasExchangeBoundaryCondition(; 
-        water_concentration = CarbonDioxideConcentration(; carbon_chemistry, 
-                                                            DIC = :DIC2,
-                                                            Alk = :Alk2)
+        water_concentration = CarbonDioxideConcentration(; DIC = :DIC2,
+                                                           Alk = :Alk2)
     )
 
 wind = FluxBoundaryCondition(-1.2/1026*2e-3*10^2)

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -18,8 +18,7 @@ using Oceananigans, OceanBioME, Oceananigans.Units
 using OceanBioME.Models.GasExchangeModel: CarbonDioxideConcentration
 
 # we define the grid and the biogeochemistry, adding in the `carbonate_system` with 2 replicates
-grid = RectilinearGrid(GPU(); 
-                       size = (64, 64, 8), 
+grid = RectilinearGrid(size = (64, 64, 8), 
                        extent = (500, 500, 15))
 
 biogeochemistry = LOBSTER(grid;

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -17,6 +17,7 @@ using Oceananigans, OceanBioME, Oceananigans.Units
 
 using OceanBioME.Models.GasExchangeModel: CarbonDioxideConcentration
 
+# we define the grid and the biogeochemistry, adding in the `carbonate_system` with 2 replicates
 grid = RectilinearGrid(GPU(); 
                        size = (64, 64, 8), 
                        extent = (500, 500, 15))
@@ -24,24 +25,36 @@ grid = RectilinearGrid(GPU();
 biogeochemistry = LOBSTER(grid;
                           carbonate_system = CarbonateSystem(2))
 
+# Next we have to construct the boundary conditions for the DIC, changing the defaults to 
+# specify that the DIC and Alkalinity for the calculation should be DIC1 and Alk1/DIC2 
+# and Alk2. Then we can put the boundary conditions together.
+wind_speed = 5 # m/s
+Cᴰ = 2e-3
+ρₐ = 1.2
+ρₒ = 1026
+
 CO₂_flux1 = 
     CarbonDioxideGasExchangeBoundaryCondition(; 
+        wind_speed,
         water_concentration = CarbonDioxideConcentration(; DIC = :DIC1,
                                                            Alk = :Alk1)
     )
 CO₂_flux2 = 
     CarbonDioxideGasExchangeBoundaryCondition(; 
+        wind_speed,
         water_concentration = CarbonDioxideConcentration(; DIC = :DIC2,
                                                            Alk = :Alk2)
     )
 
-wind = FluxBoundaryCondition(-1.2/1026*2e-3*10^2)
+wind = FluxBoundaryCondition(-ρₐ/ρₒ * Cᴰ * wind_speed^2)
 
 boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
                          DIC2 = FieldBoundaryConditions(top = CO₂_flux2),
                          u    = FieldBoundaryConditions(top = wind))
 
-@inline oae_release(x, y, z, t, params) = 
+# Next we define an alkalinity release in a circle in the center for 1 hour
+
+@inline alkalinity_release(x, y, z, t, params) = 
     ifelse((params.start_time <= t < params.start_time + params.duration) & 
             (z > params.depth) & 
             ((x-250)^2 + (y-250)^2 < params.radius^2), 
@@ -53,11 +66,15 @@ depth = -1
 radius = 50
 release_rate = total_release/duration/(π*radius^2*abs(depth))
 
-oae = Forcing(oae_release; parameters = (; start_time = 20minutes, 
-                                           duration, 
-                                           release_rate, 
-                                           radius, 
-                                           depth)) 
+oae = Forcing(alkalinity_release; 
+              parameters = (; start_time = 20minutes, 
+                              duration, 
+                              release_rate, 
+                              radius, 
+                              depth)) 
+
+# And then put the model together with `Alk2` having the release 
+# while Alk1 evolves normally
 
 model = NonhydrostaticModel(grid;
                             coriolis = FPlane(latitude = 45),
@@ -73,6 +90,9 @@ set!(model, P = 1, NO₃ = 10,
             DIC2 = 2000, Alk2 = 2300, 
             u = (x, y, z) -> randn()/2)
 
+# Then we can setup a simulation with a variable timestep and progress message
+# and output the tracers
+
 simulation = Simulation(model, Δt = 5, stop_time = 2hours)
 
 conjure_time_step_wizard!(simulation)
@@ -87,6 +107,9 @@ simulation.output_writers[:tracers] = JLD2Writer(model, model.tracers;
                                                 schedule = AveragedTimeInterval(5minutes),
                                                 overwrite_existing = true)
 
+# We can also create a `BoundaryConditionOperation` which records the flux through the
+# top boundary for both the DIC fields which we can save
+
 qCO₂1 = BoundaryConditionOperation(model.tracers.DIC1, :top, model)
 qCO₂2 = BoundaryConditionOperation(model.tracers.DIC2, :top, model)
 
@@ -97,7 +120,11 @@ simulation.output_writers[:carbon_flux] = JLD2Writer(model, (; qCO₂1, qCO₂2)
                                                      schedule = TimeInterval(5minutes),
                                                      overwrite_existing = true)
 
+# and then run the simulation
+
 run!(simulation)
+
+# Finally we load the data and create some plots
 
 using CairoMakie, Statistics
 

--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -136,7 +136,7 @@ n = Observable(1)
 N = length(fds["P"])
 
 Δ_Alk = @lift (mean(interior(fds["Alk2"][$n]), dims=3)[:, :, 1] .- 
-               mean(interior(fds["Alk1"][$n]), dims=3)[1, 1, :]).* 15
+               mean(interior(fds["Alk1"][$n]), dims=3)[:, :, 1]).* 15
 Δ_qCO₂ = @lift (interior(fds_surface["qCO₂2"][$n], :, :, 1) .- 
                 interior(fds_surface["qCO₂1"][$n], :, :, 1)) .* (12+2*16)*1e-3*day
 

--- a/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
+++ b/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
@@ -27,9 +27,16 @@ biogeochemistry and *does not* effect any other groups (e.g. acidifcation does
 not effect phytoplankton growth). To capture this effect a different `plankton` 
 could be defined.
 """
-struct CarbonateSystem end
+struct CarbonateSystem{N} end
 
-required_biogeochemical_tracers(::CarbonateSystem) = (:DIC, :Alk)
+function CarbonateSystem(replicates = 1)
+    manifest_carbonate_replicates!(replicates)
+
+    return CarbonateSystem{replicates}()
+end
+
+required_biogeochemical_tracers(::CarbonateSystem{1}) = (:DIC, :Alk)
+required_biogeochemical_tracers(::CarbonateSystem{N}) where N = (map(n->Symbol(:DIC, n), 1:N)..., map(n->Symbol(:Alk, n), 1:N)...)
 
 @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{:DIC}, clock, fields, auxiliary_fields) = (
   - phytoplankton_primary_production(lobster, i, j, k, fields, auxiliary_fields)
@@ -47,3 +54,16 @@ required_biogeochemical_tracers(::CarbonateSystem) = (:DIC, :Alk)
     nutrient_uptake(lobster, i, j, k, Val(:N), fields, auxiliary_fields)
   - calcite_uptake(lobster, i, j, k, fields, auxiliary_fields)
 )
+
+function manifest_carbonate_replicates!(N)
+    for n in 1:N
+        DIC_name = Symbol(:DIC, n)
+        Alk_name = Symbol(:Alk, n)
+        @eval begin
+            @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{$(QuoteNode(DIC_name))}, clock, fields, auxiliary_fields) =
+                lobster(i, j, k, grid, Val(:DIC), clock, fields, auxiliary_fields)
+            @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{$(QuoteNode(Alk_name))}, clock, fields, auxiliary_fields) =
+                lobster(i, j, k, grid, Val(:Alk), clock, fields, auxiliary_fields)
+        end
+    end
+end

--- a/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
+++ b/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
@@ -30,6 +30,9 @@ could be defined.
 Multiple (N) instances of the carbonate system can evolve in parallel and the tracers
 will be named `DIC1` ... `DICN` and `Alk1` ... `AlkN`. This is setup by passing an 
 integer argument when the model is constructed like `CarbonateSystem(2)`.
+
+You may get method overwrite warnings if you repeatedly define carbonate systems
+with N>1, this shouldn't cause problems.
 """
 struct CarbonateSystem{N} end
 

--- a/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
+++ b/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
@@ -1,5 +1,5 @@
 """
-    CarbonateSystem
+    CarbonateSystem{N}
 
 `CarbonateSystem` defines the carbonate system for the `LOBSTER` biogeochemical
 model and evolves dissolved inorganic carbon (`DIC`) and alkalinity (`Alk`).
@@ -26,6 +26,10 @@ the uptake of calcite into phytoplankton.
 biogeochemistry and *does not* effect any other groups (e.g. acidifcation does
 not effect phytoplankton growth). To capture this effect a different `plankton` 
 could be defined.
+
+Multiple (N) instances of the carbonate system can evolve in parallel and the tracers
+will be named `DIC1` ... `DICN` and `Alk1` ... `AlkN`. This is setup by passing an 
+integer argument when the model is constructed like `CarbonateSystem(2)`.
 """
 struct CarbonateSystem{N} end
 

--- a/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
+++ b/src/Models/AdvectedPopulations/NutrientsPlanktonDetritus/carbonate_system.jl
@@ -60,14 +60,16 @@ required_biogeochemical_tracers(::CarbonateSystem{N}) where N = (map(n->Symbol(:
 )
 
 function manifest_carbonate_replicates!(N)
-    for n in 1:N
-        DIC_name = Symbol(:DIC, n)
-        Alk_name = Symbol(:Alk, n)
-        @eval begin
-            @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{$(QuoteNode(DIC_name))}, clock, fields, auxiliary_fields) =
-                lobster(i, j, k, grid, Val(:DIC), clock, fields, auxiliary_fields)
-            @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{$(QuoteNode(Alk_name))}, clock, fields, auxiliary_fields) =
-                lobster(i, j, k, grid, Val(:Alk), clock, fields, auxiliary_fields)
-        end
+    if N>1
+      for n in 1:N
+          DIC_name = Symbol(:DIC, n)
+          Alk_name = Symbol(:Alk, n)
+          @eval begin
+              @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{$(QuoteNode(DIC_name))}, clock, fields, auxiliary_fields) =
+                  lobster(i, j, k, grid, Val(:DIC), clock, fields, auxiliary_fields)
+              @inline (lobster::NutrientsPlanktonDetritus{<:Any, <:Any, <:Any, <:CarbonateSystem})(i, j, k, grid, ::Val{$(QuoteNode(Alk_name))}, clock, fields, auxiliary_fields) =
+                  lobster(i, j, k, grid, Val(:Alk), clock, fields, auxiliary_fields)
+          end
+      end
     end
 end

--- a/src/Models/GasExchange/carbon_dioxide_concentration.jl
+++ b/src/Models/GasExchange/carbon_dioxide_concentration.jl
@@ -7,7 +7,7 @@
 Converts fCO₂ to partial pressure as per Dickson, A.G., Sabine, C.L. and  Christian, J.R. (2007), 
 Guide to Best Practices for Ocean CO 2 Measurements. PICES Special Publication 3, 191 pp.
 """
-struct CarbonDioxideConcentration{CC<:CarbonChemistry, FV, CV, AP, SP}
+struct CarbonDioxideConcentration{DIC, Alk, CC<:CarbonChemistry, FV, CV, AP, SP}
             carbon_chemistry :: CC 
     first_virial_coefficient :: FV
     cross_virial_coefficient :: CV
@@ -20,17 +20,21 @@ CarbonDioxideConcentration(FT = Float64;
                            first_virial_coefficient::FV = PolynomialVirialCoefficientForCarbonDioxide{FT}(),
                            cross_virial_coefficient::CV = CrossVirialCoefficientForCarbonDioxide{FT}(),
                            air_pressure::AP = one(FT), # atm
-                           silicate_and_phosphate_names::SP = nothing) where {CC, FV, CV, AP, SP} = 
-    CarbonDioxideConcentration(carbon_chemistry, first_virial_coefficient, cross_virial_coefficient, air_pressure, silicate_and_phosphate_names)
-
-                            
+                           silicate_and_phosphate_names::SP = nothing,
+                           DIC = :DIC,
+                           Alk = :Alk) where {CC, FV, CV, AP, SP} = 
+    CarbonDioxideConcentration{DIC, Alk, CC, FV, CV, AP, SP}(carbon_chemistry, 
+                                                             first_virial_coefficient, 
+                                                             cross_virial_coefficient, 
+                                                             air_pressure, 
+                                                             silicate_and_phosphate_names)
 
 summary(::CarbonDioxideConcentration{CC, FV, CV, AP}) where {CC, FV, CV, AP} = 
     "`CarbonChemistry` derived partial pressure of CO₂ (pCO₂) {$(nameof(CC)), $(nameof(FV)), $(nameof(CV))}"
 
-@inline function surface_value(cc::CarbonDioxideConcentration, i, j, grid, clock, model_fields)
-    DIC = @inbounds model_fields.DIC[i, j, grid.Nz]
-    Alk = @inbounds model_fields.Alk[i, j, grid.Nz]
+@inline function surface_value(cc::CarbonDioxideConcentration{DIC_name, Alk_name}, i, j, grid, clock, model_fields) where {DIC_name, Alk_name}
+    DIC = @inbounds model_fields[DIC_name][i, j, grid.Nz] # this is a compile time inference so is fine on GPU
+    Alk = @inbounds model_fields[Alk_name][i, j, grid.Nz]
 
     T = @inbounds model_fields.T[i, j, grid.Nz]
     S = @inbounds model_fields.S[i, j, grid.Nz]

--- a/src/Models/GasExchange/carbon_dioxide_concentration.jl
+++ b/src/Models/GasExchange/carbon_dioxide_concentration.jl
@@ -1,11 +1,17 @@
 """
-    CarbonDioxideConcentration(; carbon_chemistry, 
-                                 first_virial_coefficient = PolynomialVirialCoefficientForCarbonDioxide(),
-                                 cross_viral_coefficient = CrossVirialCoefficientForCarbonDioxide(),
-                                 air_pressue = 1 # atm)
+    CarbonDioxideConcentration(FT = Float64;
+                               carbon_chemistry::CC,
+                               first_virial_coefficient::FV = PolynomialVirialCoefficientForCarbonDioxide{FT}(),
+                               cross_virial_coefficient::CV = CrossVirialCoefficientForCarbonDioxide{FT}(),
+                               air_pressure::AP = one(FT), # atm
+                               silicate_and_phosphate_names::SP = nothing,
+                               DIC = :DIC,
+                               Alk = :Alk)
 
 Converts fCO₂ to partial pressure as per Dickson, A.G., Sabine, C.L. and  Christian, J.R. (2007), 
 Guide to Best Practices for Ocean CO 2 Measurements. PICES Special Publication 3, 191 pp.
+
+`DIC` and `Alk` specify the tracer names of the DIC and alkalinity in the model.
 """
 struct CarbonDioxideConcentration{DIC, Alk, CC<:CarbonChemistry, FV, CV, AP, SP}
             carbon_chemistry :: CC 

--- a/src/Models/GasExchange/carbon_dioxide_concentration.jl
+++ b/src/Models/GasExchange/carbon_dioxide_concentration.jl
@@ -22,7 +22,7 @@ silicate_and_phosphate_names :: SP
 end
 
 CarbonDioxideConcentration(FT = Float64;
-                           carbon_chemistry::CC,
+                           carbon_chemistry::CC = CarbonChemistry(),
                            first_virial_coefficient::FV = PolynomialVirialCoefficientForCarbonDioxide{FT}(),
                            cross_virial_coefficient::CV = CrossVirialCoefficientForCarbonDioxide{FT}(),
                            air_pressure::AP = one(FT), # atm

--- a/src/Models/GasExchange/carbon_dioxide_concentration.jl
+++ b/src/Models/GasExchange/carbon_dioxide_concentration.jl
@@ -35,8 +35,15 @@ CarbonDioxideConcentration(FT = Float64;
                                                              air_pressure, 
                                                              silicate_and_phosphate_names)
 
-summary(::CarbonDioxideConcentration{CC, FV, CV, AP}) where {CC, FV, CV, AP} = 
-    "`CarbonChemistry` derived partial pressure of CO₂ (pCO₂) {$(nameof(CC)), $(nameof(FV)), $(nameof(CV))}"
+summary(::CarbonDioxideConcentration{DIC, Alk, CC, FV, CV, AP}) where {DIC, Alk, CC, FV, CV, AP} = 
+    "`CarbonChemistry` derived partial pressure of CO₂ (pCO₂) {$DIC, $Alk, $(nameof(CC)), $(nameof(FV)), $(nameof(CV))}"
+
+show(io::IO, c::CarbonDioxideConcentration{DIC, Alk, CC, FV, CV, AP}) where {DIC, Alk, CC, FV, CV, AP} = 
+    println(io, "`CarbonChemistry` derived partial pressure of CO₂ (pCO₂) \n",
+            "    Solves the $(nameof(CC)) based on $DIC and $Alk,\n",
+            "    using $(nameof(FV)), \n",
+            "          $(nameof(CV)), \n",
+            "          at Pₐₜₘ = $(c.air_pressure)atm")
 
 @inline function surface_value(cc::CarbonDioxideConcentration{DIC_name, Alk_name}, i, j, grid, clock, model_fields) where {DIC_name, Alk_name}
     DIC = @inbounds model_fields[DIC_name][i, j, grid.Nz] # this is a compile time inference so is fine on GPU
@@ -55,7 +62,6 @@ end
 @inline silicate_and_phosphate(::Nothing, args...) = (0, 0)
 @inline silicate_and_phosphate(vals::NamedTuple, args...) = values(vals)
 @inline silicate_and_phosphate(val::Tuple, model_fields) = @inbounds getproperty(model_fields, val[1]), getproperty(model_fields, val[2])
-
 
 # default values from Dickson et al., 2007
 @kwdef struct PolynomialVirialCoefficientForCarbonDioxide{FT}

--- a/test/test_gasexchange_carbon_chem.jl
+++ b/test/test_gasexchange_carbon_chem.jl
@@ -30,7 +30,48 @@ function test_gas_exchange_model(grid, air_concentration)
     # is everything communicating properly? (can't think of a way to not use allow scalar here)
     value = CUDA.@allowscalar Oceananigans.getbc(model.tracers.DIC.boundary_conditions.top, 1, 1, grid, model.clock, fields(model))
 
-    return isa(model.tracers.DIC.boundary_conditions.top.condition.func, GasExchange)&&≈(value, -8e-6; atol = 1e-6)&&isnothing(time_step!(model, 1.0))
+    @test isa(model.tracers.DIC.boundary_conditions.top.condition.func, GasExchange)
+    @test ≈(value, -8e-6; atol = 1e-6)
+    @test isnothing(time_step!(model, 1.0))
+
+    # multiple carbonate systems
+
+    CO₂_flux1 = 
+        CarbonDioxideGasExchangeBoundaryCondition(; 
+            water_concentration = CarbonDioxideConcentration(; DIC = :DIC1,
+                                                            Alk = :Alk1)
+        )
+    CO₂_flux2 = 
+        CarbonDioxideGasExchangeBoundaryCondition(; 
+            water_concentration = CarbonDioxideConcentration(; DIC = :DIC2,
+                                                            Alk = :Alk2)
+        )
+
+
+    boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
+                             DIC2 = FieldBoundaryConditions(top = CO₂_flux2))
+
+    model = NonhydrostaticModel(grid;
+                                tracers = (:T, :S),
+                                biogeochemistry = LOBSTER(grid; carbonate_system = CarbonateSystem(2)),
+                                boundary_conditions)
+
+    set!(model, T = 15.0, S = 35.0, DIC1 = 2220, Alk1 = 2500, DIC2 = 2221, Alk2 = 2501)
+
+    # maybe this should use BoundaryConditionOperation
+    value1 = CUDA.@allowscalar Oceananigans.getbc(model.tracers.DIC1.boundary_conditions.top, 1, 1, grid, model.clock, fields(model))
+    value2 = CUDA.@allowscalar Oceananigans.getbc(model.tracers.DIC2.boundary_conditions.top, 1, 1, grid, model.clock, fields(model))
+
+    @test isa(model.tracers.DIC1.boundary_conditions.top.condition.func, GasExchange)
+    @test ≈(value1, -8e-6; atol = 1e-6)
+
+    @test isa(model.tracers.DIC2.boundary_conditions.top.condition.func, GasExchange)
+    @test ≈(value2, -8e-6; atol = 1e-6)
+
+    @test value1 != value2
+
+    @test isnothing(time_step!(model, 1.0))
+    return nothing
 end
 
 @testset "pCO₂ values" begin
@@ -65,7 +106,7 @@ set!(conc_field, (args...) -> 413)
 @testset "Gas exchange coupling" begin
     for air_concentration in [413.1, conc_function, conc_field]
         @info "Testing gas exchange with $(typeof(air_concentration))"
-        @test test_gas_exchange_model(grid, air_concentration)
+        test_gas_exchange_model(grid, air_concentration)
     end
 end
 

--- a/test/test_gasexchange_carbon_chem.jl
+++ b/test/test_gasexchange_carbon_chem.jl
@@ -5,7 +5,7 @@ using Oceananigans, Oceananigans.Units, DataDeps, JLD2, Statistics
 using Oceananigans.Fields: ConstantField
 
 using OceanBioME: GasExchange, LOBSTER, CarbonChemistry
-using OceanBioME.Models.GasExchangeModel: surface_value
+using OceanBioME.Models.GasExchangeModel: surface_value, CarbonDioxideConcentration
 
 using OceanBioME.Models.CarbonChemistryModel: IonicStrength, K0, K1, K2, KB, KW, KS, KF, KP, KSi, KSP_aragonite, KSP_calcite
 


### PR DESCRIPTION
This PR generalises `CarbonateSystem` to allow `N` instances of DIC and alkalinity by passing the number as an argument e.g. `CarbonateSystem(2)`. This makes N copies of DIC and Alk named DIC1, DIC2, ..., DICN etc.

This PR also adds an idealised OAE example.

<img width="1200" height="900" alt="total_change" src="https://github.com/user-attachments/assets/7367461e-3994-4233-a9de-17a09e3642eb" />

https://github.com/user-attachments/assets/b443c8ef-3f8e-4231-88b9-3030df2c9c51



To do:

- [x] Check example
- [x] Add tests for `CarbonDioxideConcentration` and `CarbonateSystem`
- [x] Update docstrings

@ElizabethYankovsky @lgloege @johnryantaylor 

~This PR currently includes #355 but I will rebase when it is merged.~ done

~Blocked by #355,~ closes #363 and #361 