### PR TITLE
Automates DIC boundary condition setup for multiple 

### DIFF
--- a/examples/oae_experiment.jl
+++ b/examples/oae_experiment.jl
@@ -32,23 +32,12 @@ Cᴰ = 2e-3
 ρₐ = 1.2
 ρₒ = 1026
 
-CO₂_flux1 = 
-    CarbonDioxideGasExchangeBoundaryCondition(; 
-        wind_speed,
-        water_concentration = CarbonDioxideConcentration(; DIC = :DIC1,
-                                                           Alk = :Alk1)
-    )
-CO₂_flux2 = 
-    CarbonDioxideGasExchangeBoundaryCondition(; 
-        wind_speed,
-        water_concentration = CarbonDioxideConcentration(; DIC = :DIC2,
-                                                           Alk = :Alk2)
-    )
+CO₂_fluxes = CarbonDioxideGasExchangeBoundaryConditions(2; wind_speed)
 
 wind = FluxBoundaryCondition(-ρₐ/ρₒ * Cᴰ * wind_speed^2)
 
-boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
-                         DIC2 = FieldBoundaryConditions(top = CO₂_flux2),
+boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_fluxes.DIC1),
+                         DIC2 = FieldBoundaryConditions(top = CO₂_fluxes.DIC2),
                          u    = FieldBoundaryConditions(top = wind))
 
 # Next we define an alkalinity release in a circle in the center for 1 hour

--- a/src/Models/GasExchange/GasExchange.jl
+++ b/src/Models/GasExchange/GasExchange.jl
@@ -4,7 +4,8 @@
 module GasExchangeModel
 
 export GasExchange, 
-       CarbonDioxideGasExchangeBoundaryCondition, 
+       CarbonDioxideGasExchangeBoundaryCondition,
+       CarbonDioxideGasExchangeBoundaryConditions, 
        OxygenGasExchangeBoundaryCondition, 
        GasExchangeBoundaryCondition,
        ScaledGasTransferVelocity,
@@ -101,27 +102,94 @@ and phosphate tracers, or a `NamedTuple`  of values for the `carbon_chemistry` m
 
 Note: The model always requires `T`, `S`, `DIC`, and `Alk` to be present in the model.
 """
-function CarbonDioxideGasExchangeBoundaryCondition(FT = Float64; 
-                                                   carbon_chemistry = CarbonChemistry(FT),
-                                                   transfer_velocity = 
-                                                        SchmidtScaledTransferVelocity(FT; 
-                                                           schmidt_number = CarbonDioxidePolynomialSchmidtNumber(FT),
-                                                           solubility = MolPerKgPerAtmToMMolPerCubicMPerMicroAtm(carbon_chemistry.solubility,
-                                                                                                                 carbon_chemistry.density_function)),
-                                                   air_concentration = 413, # ppmv
-                                                   wind_speed = 2,
-                                                   water_concentration = nothing,
-                                                   silicate_and_phosphate_names = nothing,
-                                                   kwargs...)
+CarbonDioxideGasExchangeBoundaryCondition(FT = Float64; 
+                                          carbon_chemistry = CarbonChemistry(FT),
+                                          transfer_velocity = 
+                                               SchmidtScaledTransferVelocity(FT; 
+                                                  schmidt_number = CarbonDioxidePolynomialSchmidtNumber(FT),
+                                                  solubility = MolPerKgPerAtmToMMolPerCubicMPerMicroAtm(carbon_chemistry.solubility,
+                                                                                                        carbon_chemistry.density_function)),
+                                          air_concentration = 413, # ppmv
+                                          wind_speed = 2,
+                                          water_concentration = nothing,
+                                          silicate_and_phosphate_names = nothing,
+                                          kwargs...) =
+    CarbonDioxideGasExchangeBoundaryConditions(1, FT;
+                                               carbon_chemistry,
+                                               transfer_velocity,
+                                               air_concentration,
+                                               wind_speed,
+                                               water_concentration,
+                                               silicate_and_phosphate_names,
+                                               kwargs...)
+
+
+"""
+    CarbonDioxideGasExchangeBoundaryConditions(N = 1, FT = Float64; 
+                                               carbon_chemistry = CarbonChemistry(FT),
+                                               transfer_velocity = SchmidtScaledTransferVelocity(schmidt_number = CarbonDioxidePolynomialSchmidtNumber(FT)),
+                                               air_concentration = 413, # ppmv
+                                               wind_speed = 2,
+                                               water_concentration = nothing,
+                                               silicate_and_phosphate_names = nothing,
+                                               kwargs...)
+
+Returns a `FluxBoundaryCondition` for the gas exchange between carbon dioxide dissolved in the water
+specified by the `carbon_chemisty` model, and `air_concentration` with `transfer_velocity` (see 
+`GasExchangeBoundaryCondition` for details).
+
+`silicate_and_phosphate_names` should either be `nothing`, a `Tuple`` of symbols specifying the name of the silicate
+and phosphate tracers, or a `NamedTuple`  of values for the `carbon_chemistry` model.
+
+`kwargs` are passed on to `GasExchangeBoundaryCondition`.
+
+Note: The model always requires `T`, `S`, `DIC`, and `Alk` to be present in the model.
+"""
+function CarbonDioxideGasExchangeBoundaryConditions(N = 1, FT = Float64; 
+                                                    carbon_chemistry = CarbonChemistry(FT),
+                                                    transfer_velocity = 
+                                                         SchmidtScaledTransferVelocity(FT; 
+                                                            schmidt_number = CarbonDioxidePolynomialSchmidtNumber(FT),
+                                                            solubility = MolPerKgPerAtmToMMolPerCubicMPerMicroAtm(carbon_chemistry.solubility,
+                                                                                                                  carbon_chemistry.density_function)),
+                                                    air_concentration = 413, # ppmv
+                                                    wind_speed = 2,
+                                                    water_concentration = nothing,
+                                                    silicate_and_phosphate_names = nothing,
+                                                    kwargs...)
 
     if isnothing(water_concentration)
-        water_concentration = CarbonDioxideConcentration(FT; carbon_chemistry, silicate_and_phosphate_names)
-    elseif !isnothing(carbon_chemistry)
-        @warn "Make sure that the `carbon_chemistry` $(carbon_chemistry) is the same as that in `water_concentration` $(water_concentration) (or set it to `nothing`)"
+        if N == 1
+            water_concentration = CarbonDioxideConcentration(FT; carbon_chemistry, silicate_and_phosphate_names)
+        else
+            water_concentration = map(
+                n->CarbonDioxideConcentration(FT; carbon_chemistry, 
+                                                  silicate_and_phosphate_names,
+                                                  DIC = Symbol(:DIC, n),
+                                                  Alk = Symbol(:Alk, n)),
+                1:N)
+        end
     end
 
-    return GasExchangeBoundaryCondition(FT; water_concentration, air_concentration, transfer_velocity, wind_speed, kwargs...)
+    if N == 1
+        return GasExchangeBoundaryCondition(FT; water_concentration, air_concentration, transfer_velocity, wind_speed, kwargs...)
+    else
+        dic_names = tuple(map(n->Symbol(:DIC, n), 1:N)...)
+        dic_boundary_kwargs = (; water_concentration, air_concentration, transfer_velocity, wind_speed, kwargs...)
+        return NamedTuple{dic_names}(map(n->materialise_multiple_dic_boundaries(n, FT; dic_boundary_kwargs...), 1:N))
+    end
 end
+
+materialise_multiple_dic_boundaries(n, FT; water_concentration, air_concentration, transfer_velocity, wind_speed, kwargs...) =
+    GasExchangeBoundaryCondition(FT; water_concentration = one_or_nth(water_concentration, n),
+                                     air_concentration = one_or_nth(air_concentration, n),
+                                     transfer_velocity = one_or_nth(transfer_velocity, n),
+                                     wind_speed = one_or_nth(wind_speed, n),
+                                     kwargs...)
+
+one_or_nth(only_one, n) = only_one
+one_or_nth(n_options::Array, n) = n_options[n]
+one_or_nth(n_options::Tuple, n) = n_options[n]
 
 """
     OxygenGasExchangeBoundaryCondition(FT = Float64; 

--- a/src/Models/Models.jl
+++ b/src/Models/Models.jl
@@ -13,6 +13,7 @@ export CarbonChemistry
 
 export GasExchange, 
        CarbonDioxideGasExchangeBoundaryCondition, 
+       CarbonDioxideGasExchangeBoundaryConditions,
        OxygenGasExchangeBoundaryCondition, 
        GasExchangeBoundaryCondition,
        ScaledGasTransferVelocity,

--- a/src/OceanBioME.jl
+++ b/src/OceanBioME.jl
@@ -26,7 +26,11 @@ export TwoBandPhotosyntheticallyActiveRadiation,
        MultiBandPhotosyntheticallyActiveRadiation
 
 # airsea flux
-export GasExchange, CarbonDioxideGasExchangeBoundaryCondition, OxygenGasExchangeBoundaryCondition, GasExchangeBoundaryCondition
+export GasExchange, 
+       CarbonDioxideGasExchangeBoundaryCondition, 
+       CarbonDioxideGasExchangeBoundaryConditions, 
+       OxygenGasExchangeBoundaryCondition, 
+       GasExchangeBoundaryCondition
 
 # carbon chemistry
 export CarbonChemistry


### PR DESCRIPTION
This PR adds a possible way to streamline DIC boundary condition setup when there are multiple realisations of the carbon chemistry, e.g. the example changes:
```julia
CO₂_flux1 = 
    CarbonDioxideGasExchangeBoundaryCondition(; 
        wind_speed,
        water_concentration = CarbonDioxideConcentration(; DIC = :DIC1,
                                                           Alk = :Alk1)
    )
CO₂_flux2 = 
    CarbonDioxideGasExchangeBoundaryCondition(; 
        wind_speed,
        water_concentration = CarbonDioxideConcentration(; DIC = :DIC2,
                                                           Alk = :Alk2)
    )

wind = FluxBoundaryCondition(-ρₐ/ρₒ * Cᴰ * wind_speed^2)

boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux1),
                         DIC2 = FieldBoundaryConditions(top = CO₂_flux2),
                         u    = FieldBoundaryConditions(top = wind))
```

to 
```julia
CO₂_fluxes = CarbonDioxideGasExchangeBoundaryConditions(2; wind_speed)

wind = FluxBoundaryCondition(-ρₐ/ρₒ * Cᴰ * wind_speed^2)

boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_fluxes.DIC1),
                         DIC2 = FieldBoundaryConditions(top = CO₂_fluxes.DIC2),
                         u    = FieldBoundaryConditions(top = wind))
```

This is still a bit cumbersome and it would be nice to just do:
```julia
CO₂_flux = CarbonDioxideGasExchangeBoundaryCondition(; wind_speed)

wind = FluxBoundaryCondition(-ρₐ/ρₒ * Cᴰ * wind_speed^2)

boundary_conditions = (; DIC1 = FieldBoundaryConditions(top = CO₂_flux),
                         DIC2 = FieldBoundaryConditions(top = CO₂_flux),
                         u    = FieldBoundaryConditions(top = wind))
```
but currently `regularize_boundary_condition(condition...)` does not get the field name. I'll keep on thinking of a solution, or if that would be the preferred interface propose the change in Oceananigans.

@johnryantaylor 