### PR TITLE
(0.18.3) Makes light models more generic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OceanBioME"
 uuid = "a49af516-9db8-4be4-be45-1dad61c5a376"
-version = "0.18.2"
+version = "0.18.3"
 authors = ["Jago Strong-Wright <js2430@damtp.cam.ac.uk> and contributors"]
 
 [deps]

--- a/docs/src/model_components/biogeochemical/LOBSTER.md
+++ b/docs/src/model_components/biogeochemical/LOBSTER.md
@@ -146,7 +146,7 @@ Additionally, the ``DIC`` and ``Alk`` equations are modified to replace each ``X
 | ``\alpha_d``       | `ammonia_fraction_of_detritus`         | -                  |
 | ``R_P``            | `phytoplankton_redfield`               | mmol C / mmol N    |
 | ``R_O``            | `organic_redfield`                     | mmol C / mmol N    |
-| ``R_{Chl:N}``      | `phytoplankton_chlorophyll_ratio`      | mg Chl / mmol N    |
+| ``R_{Chl:N}``      | `chlorophyll_ratio`                    | mg Chl / mmol N    |
 | ``\rho_{CaCO_3}``  | `organic_carbon_calcite_ratio`         | mmol CaCO₃/ mmol C |
 | ``R_{O_2}``        | `respiration_oxygen_nitrogen_ratio`    | mmol O / mmol N    |
 | ``R_{nit}``        | `nitrification_oxygen_nitrogen_ratio`  | mmol O / mmol N    |

--- a/docs/src/model_components/light.md
+++ b/docs/src/model_components/light.md
@@ -22,13 +22,9 @@ Light attenuation is calculated by integrating attenuation (from the surface). T
 PAR = \frac{PAR_0}{2} \left[\exp\left(k_rz + \chi_r\int_{z=0}^z Chl_r dz\right) + \exp\left(k_bz + \chi_b\int_{z=0}^z Chl_b dz\right)\right],
 ```
 
-where ``PAR_0`` is the surface value, ``k_r`` and ``k_b`` are the red and blue attenuation coefficients of water, ``\chi_r`` and ``\chi_b`` are the red and blue chlorophyll attenuation coefficients, and ``Chl_r`` and ``Chl_b`` are the red and blue chlorophyll pigment concentrations. Total chlorophyll, ``Chl``, is obtained from `chlorophyll(model.biogeochemistry, model)`, so the biogeochemistry may define it from one or more plankton or chlorophyll fields. For the `PhytoZoo` component used by `LOBSTER` and `NPZD`, this is
+where ``PAR_0`` is the surface value, ``k_r`` and ``k_b`` are the red and blue attenuation coefficients of water, ``\chi_r`` and ``\chi_b`` are the red and blue chlorophyll attenuation coefficients, and ``Chl_r`` and ``Chl_b`` are the red and blue chlorophyll pigment concentrations. Total chlorophyll, ``Chl``, is obtained from `chlorophyll(model.biogeochemistry, model)`. 
 
-```math
-Chl = R_{Chl:N} P,
-```
-
-where ``R_{Chl:N}`` is the `PhytoZoo` parameter `chlorophyll_ratio`. The red and blue pigment concentrations are then found as ``Chl_r = \left(\frac{Chl}{r_\text{pig}}\right)^{e_r}`` and ``Chl_b = \left(\frac{Chl}{r_\text{pig}}\right)^{e_b}``.
+ The red and blue pigment concentrations are then found as ``Chl_r = \left(\frac{Chl}{r_\text{pig}}\right)^{e_r}`` and ``Chl_b = \left(\frac{Chl}{r_\text{pig}}\right)^{e_b}``.
 
 ### Parameter variable names
 

--- a/docs/src/model_components/light.md
+++ b/docs/src/model_components/light.md
@@ -22,13 +22,13 @@ Light attenuation is calculated by integrating attenuation (from the surface). T
 PAR = \frac{PAR_0}{2} \left[\exp\left(k_rz + \chi_r\int_{z=0}^z Chl_r dz\right) + \exp\left(k_bz + \chi_b\int_{z=0}^z Chl_b dz\right)\right],
 ```
 
-where ``PAR_0`` is the surface value, ``k_r`` and ``k_b`` are the red and blue attenuation coefficients of water, ``\chi_r`` and ``\chi_b`` are the red and blue chlorophyll attenuation coefficients, and ``Chl_r`` and ``Chl_b`` are the red and blue chlorophyll pigment concentrations. The chlorophyll pigment concentration is derived from the phytoplankton concentration where it is assumed that the pigment concentration is given by:
+where ``PAR_0`` is the surface value, ``k_r`` and ``k_b`` are the red and blue attenuation coefficients of water, ``\chi_r`` and ``\chi_b`` are the red and blue chlorophyll attenuation coefficients, and ``Chl_r`` and ``Chl_b`` are the red and blue chlorophyll pigment concentrations. Total chlorophyll, ``Chl``, is obtained from `chlorophyll(model.biogeochemistry, model)`, so the biogeochemistry may define it from one or more plankton or chlorophyll fields. For the `PhytoZoo` component used by `LOBSTER` and `NPZD`, this is
 
 ```math
-Chl = PR_{Chl:P},
+Chl = R_{Chl:N} P,
 ```
 
-where the ratio is constant and found in [Parameters](@ref parameters). The red and blue pigment concentrations are then found as ``Chl_r = \left(\frac{Chl}{r_\text{pig}}\right)^{e_r}`` and ``Chl_b = \left(\frac{Chl}{r_\text{pig}}\right)^{e_b}``. 
+where ``R_{Chl:N}`` is the `PhytoZoo` parameter `chlorophyll_ratio`. The red and blue pigment concentrations are then found as ``Chl_r = \left(\frac{Chl}{r_\text{pig}}\right)^{e_r}`` and ``Chl_b = \left(\frac{Chl}{r_\text{pig}}\right)^{e_b}``.
 
 ### Parameter variable names
 
@@ -41,7 +41,6 @@ where the ratio is constant and found in [Parameters](@ref parameters). The red 
 | ``e_r``          | `chlorophyll_red_exponent`        | -                                 |
 | ``e_b``          | `chlorophyll_blue_exponent`       | -                                 |
 | ``r_\text{pig}`` | `pigment_ratio`                   | -                                 |
-| ``R_{Chl:P}``    | `phytoplankton_chlorophyll_ratio` | mg Chl / mmol N                   |
 
 ## Prescribed attenuation model
 

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,7 +1,7 @@
-@kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, clock, P, surface_PAR, PAR_model)
+@kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, clock, Chl, surface_fields, surface_PAR, PAR_model)
     i, j = @index(Global, NTuple)
 
-    PAR⁰ = getbc(surface_PAR, i, j, grid, clock, P)
+    PAR⁰ = getbc(surface_PAR, i, j, grid, clock, surface_fields)
 
     kʳ = PAR_model.water_red_attenuation
     kᵇ = PAR_model.water_blue_attenuation
@@ -10,23 +10,22 @@
     eʳ = PAR_model.chlorophyll_red_exponent
     eᵇ = PAR_model.chlorophyll_blue_exponent
     r  = PAR_model.pigment_ratio
-    Rᶜₚ = PAR_model.phytoplankton_chlorophyll_ratio
 
     zᶜ = znodes(grid, Center(), Center(), Center())
     zᶠ = znodes(grid, Center(), Center(), Face())
 
     # first point below surface
     @inbounds begin
-        ∫chlʳ = (zᶠ[grid.Nz + 1] - zᶜ[grid.Nz]) * (P[i, j, grid.Nz] * Rᶜₚ / r)^eʳ
-        ∫chlᵇ = (zᶠ[grid.Nz + 1] - zᶜ[grid.Nz]) * (P[i, j, grid.Nz] * Rᶜₚ / r)^eᵇ
+        ∫chlʳ = (zᶠ[grid.Nz + 1] - zᶜ[grid.Nz]) * (Chl[i, j, grid.Nz] / r)^eʳ
+        ∫chlᵇ = (zᶠ[grid.Nz + 1] - zᶜ[grid.Nz]) * (Chl[i, j, grid.Nz] / r)^eᵇ
         PAR[i, j, grid.Nz] =  PAR⁰ * (exp(kʳ * zᶜ[grid.Nz] - χʳ * ∫chlʳ) + exp(kᵇ * zᶜ[grid.Nz] - χᵇ * ∫chlᵇ)) / 2
     end
 
     # the rest of the points
     for k in grid.Nz-1:-1:1
         @inbounds begin
-            ∫chlʳ += (zᶜ[k + 1] - zᶠ[k + 1]) * (P[i, j, k + 1] * Rᶜₚ / r)^eʳ + (zᶠ[k + 1] - zᶜ[k]) * (P[i, j, k] * Rᶜₚ / r)^eʳ
-            ∫chlᵇ += (zᶜ[k + 1] - zᶠ[k + 1]) * (P[i, j, k + 1] * Rᶜₚ / r)^eᵇ + (zᶠ[k + 1] - zᶜ[k]) * (P[i, j, k] * Rᶜₚ / r)^eᵇ
+            ∫chlʳ += (zᶜ[k + 1] - zᶠ[k + 1]) * (Chl[i, j, k + 1] / r)^eʳ + (zᶠ[k + 1] - zᶜ[k]) * (Chl[i, j, k] / r)^eʳ
+            ∫chlᵇ += (zᶜ[k + 1] - zᶠ[k + 1]) * (Chl[i, j, k + 1] / r)^eᵇ + (zᶠ[k + 1] - zᶜ[k]) * (Chl[i, j, k] / r)^eᵇ
             PAR[i, j, k] =  PAR⁰ * (exp(kʳ * zᶜ[k] - χʳ * ∫chlʳ) + exp(kᵇ * zᶜ[k] - χᵇ * ∫chlᵇ)) / 2
         end
     end
@@ -41,7 +40,7 @@ struct TwoBandPhotosyntheticallyActiveRadiation{FT, F, SPAR}
     chlorophyll_blue_exponent :: FT
     pigment_ratio :: FT
 
-    phytoplankton_chlorophyll_ratio :: FT
+    phytoplankton_chlorophyll_ratio :: Union{Nothing, FT}
 
     field :: F
 
@@ -54,7 +53,7 @@ struct TwoBandPhotosyntheticallyActiveRadiation{FT, F, SPAR}
                                              chlorophyll_red_exponent::FT,
                                              chlorophyll_blue_exponent::FT,
                                              pigment_ratio::FT,
-                                             phytoplankton_chlorophyll_ratio::FT,
+                                             phytoplankton_chlorophyll_ratio::Union{Nothing, FT},
                                              field::F,
                                              surface_PAR::SPAR) where {FT, F, SPAR} =
         new{FT, F, SPAR}(water_red_attenuation,
@@ -78,14 +77,17 @@ end
                                                chlorophyll_red_exponent = 0.629,
                                                chlorophyll_blue_exponent = 0.674,
                                                pigment_ratio = 0.7,
-                                               phytoplankton_chlorophyll_ratio = 1.31,
+                                               phytoplankton_chlorophyll_ratio = nothing,
                                                surface_PAR = default_surface_PAR)
 
 Keyword Arguments
 ==================
 
 - `grid`: grid for building the model on
-- `water_red_attenuation`, ..., `phytoplankton_chlorophyll_ratio`: parameter values
+- `water_red_attenuation`, ..., `pigment_ratio`: parameter values
+- `phytoplankton_chlorophyll_ratio`: if `nothing`, chlorophyll is obtained from
+  `chlorophyll(model.biogeochemistry, model)`. A numeric value retains the direct
+  conversion from `model.tracers.P` in units of mg Chl / mmol N
 - `surface_PAR`: the photosynthetically available radiation at the surface, by default,
    assumed to have the 'continuous form' `condition(x, y t)`
 
@@ -111,7 +113,7 @@ function TwoBandPhotosyntheticallyActiveRadiation(grid::AbstractGrid{FT}, surfac
                                                   chlorophyll_red_exponent = 0.629,
                                                   chlorophyll_blue_exponent = 0.674,
                                                   pigment_ratio = 0.7,
-                                                  phytoplankton_chlorophyll_ratio = 1.31,
+                                                  phytoplankton_chlorophyll_ratio = nothing,
                                                   discrete_form = false,
                                                   parameters = nothing) where FT
 
@@ -122,7 +124,9 @@ function TwoBandPhotosyntheticallyActiveRadiation(grid::AbstractGrid{FT}, surfac
     chlorophyll_red_exponent = convert(FT, chlorophyll_red_exponent)
     chlorophyll_blue_exponent = convert(FT, chlorophyll_blue_exponent)
     pigment_ratio = convert(FT, pigment_ratio)
-    phytoplankton_chlorophyll_ratio = convert(FT, phytoplankton_chlorophyll_ratio)
+    if !isnothing(phytoplankton_chlorophyll_ratio)
+        phytoplankton_chlorophyll_ratio = convert(FT, phytoplankton_chlorophyll_ratio)
+    end
 
     boundary_condition_kwargs = surface_PAR isa Function ? (; parameters, discrete_form) : NamedTuple()
 
@@ -146,10 +150,15 @@ function TwoBandPhotosyntheticallyActiveRadiation(grid::AbstractGrid{FT}, surfac
                                                     surface_PAR)
 end
 
+@inline two_band_chlorophyll(model, ::Nothing) = chlorophyll(model.biogeochemistry, model)
+@inline two_band_chlorophyll(model, ratio) = ratio * model.tracers.P
+
 function update_biogeochemical_state!(model, PAR::TwoBandPhotosyntheticallyActiveRadiation)
     arch = architecture(model.grid)
+    Chl = two_band_chlorophyll(model, PAR.phytoplankton_chlorophyll_ratio)
+    surface_fields = hasproperty(model.tracers, :P) ? model.tracers.P : Chl
 
-    launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.clock, model.tracers.P, PAR.surface_PAR, PAR)
+    launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.clock, Chl, surface_fields, PAR.surface_PAR, PAR)
     #fill_halo_regions!(PAR.field, model.clock, fields(model))
 
     return nothing

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -1,7 +1,7 @@
-@kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, clock, Chl, surface_fields, surface_PAR, PAR_model)
+@kernel function update_TwoBandPhotosyntheticallyActiveRadiation!(PAR, grid, clock, Chl, surface_PAR, PAR_model)
     i, j = @index(Global, NTuple)
 
-    PAR⁰ = getbc(surface_PAR, i, j, grid, clock, surface_fields)
+    PAR⁰ = getbc(surface_PAR, i, j, grid, clock, Chl)
 
     kʳ = PAR_model.water_red_attenuation
     kᵇ = PAR_model.water_blue_attenuation
@@ -40,8 +40,6 @@ struct TwoBandPhotosyntheticallyActiveRadiation{FT, F, SPAR}
     chlorophyll_blue_exponent :: FT
     pigment_ratio :: FT
 
-    phytoplankton_chlorophyll_ratio :: Union{Nothing, FT}
-
     field :: F
 
     surface_PAR :: SPAR
@@ -53,7 +51,6 @@ struct TwoBandPhotosyntheticallyActiveRadiation{FT, F, SPAR}
                                              chlorophyll_red_exponent::FT,
                                              chlorophyll_blue_exponent::FT,
                                              pigment_ratio::FT,
-                                             phytoplankton_chlorophyll_ratio::Union{Nothing, FT},
                                              field::F,
                                              surface_PAR::SPAR) where {FT, F, SPAR} =
         new{FT, F, SPAR}(water_red_attenuation,
@@ -63,7 +60,6 @@ struct TwoBandPhotosyntheticallyActiveRadiation{FT, F, SPAR}
                          chlorophyll_red_exponent,
                          chlorophyll_blue_exponent,
                          pigment_ratio,
-                         phytoplankton_chlorophyll_ratio,
                          field,
                          surface_PAR)
 end
@@ -77,17 +73,16 @@ end
                                                chlorophyll_red_exponent = 0.629,
                                                chlorophyll_blue_exponent = 0.674,
                                                pigment_ratio = 0.7,
-                                               phytoplankton_chlorophyll_ratio = nothing,
                                                surface_PAR = default_surface_PAR)
+
+Total chlorophyll is obtained from `chlorophyll(model.biogeochemistry, model)`, allowing the
+biogeochemistry to define chlorophyll from one or more plankton or chlorophyll fields.
 
 Keyword Arguments
 ==================
 
 - `grid`: grid for building the model on
 - `water_red_attenuation`, ..., `pigment_ratio`: parameter values
-- `phytoplankton_chlorophyll_ratio`: if `nothing`, chlorophyll is obtained from
-  `chlorophyll(model.biogeochemistry, model)`. A numeric value retains the direct
-  conversion from `model.tracers.P` in units of mg Chl / mmol N
 - `surface_PAR`: the photosynthetically available radiation at the surface, by default,
    assumed to have the 'continuous form' `condition(x, y t)`
 
@@ -113,7 +108,6 @@ function TwoBandPhotosyntheticallyActiveRadiation(grid::AbstractGrid{FT}, surfac
                                                   chlorophyll_red_exponent = 0.629,
                                                   chlorophyll_blue_exponent = 0.674,
                                                   pigment_ratio = 0.7,
-                                                  phytoplankton_chlorophyll_ratio = nothing,
                                                   discrete_form = false,
                                                   parameters = nothing) where FT
 
@@ -124,9 +118,6 @@ function TwoBandPhotosyntheticallyActiveRadiation(grid::AbstractGrid{FT}, surfac
     chlorophyll_red_exponent = convert(FT, chlorophyll_red_exponent)
     chlorophyll_blue_exponent = convert(FT, chlorophyll_blue_exponent)
     pigment_ratio = convert(FT, pigment_ratio)
-    if !isnothing(phytoplankton_chlorophyll_ratio)
-        phytoplankton_chlorophyll_ratio = convert(FT, phytoplankton_chlorophyll_ratio)
-    end
 
     boundary_condition_kwargs = surface_PAR isa Function ? (; parameters, discrete_form) : NamedTuple()
 
@@ -145,20 +136,15 @@ function TwoBandPhotosyntheticallyActiveRadiation(grid::AbstractGrid{FT}, surfac
                                                     chlorophyll_red_exponent,
                                                     chlorophyll_blue_exponent,
                                                     pigment_ratio,
-                                                    phytoplankton_chlorophyll_ratio,
                                                     field,
                                                     surface_PAR)
 end
 
-@inline two_band_chlorophyll(model, ::Nothing) = chlorophyll(model.biogeochemistry, model)
-@inline two_band_chlorophyll(model, ratio) = ratio * model.tracers.P
-
 function update_biogeochemical_state!(model, PAR::TwoBandPhotosyntheticallyActiveRadiation)
     arch = architecture(model.grid)
-    Chl = two_band_chlorophyll(model, PAR.phytoplankton_chlorophyll_ratio)
-    surface_fields = hasproperty(model.tracers, :P) ? model.tracers.P : Chl
+    Chl = chlorophyll(model.biogeochemistry, model)
 
-    launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.clock, Chl, surface_fields, PAR.surface_PAR, PAR)
+    launch!(arch, model.grid, :xy, update_TwoBandPhotosyntheticallyActiveRadiation!, PAR.field, model.grid, model.clock, Chl, PAR.surface_PAR, PAR)
     #fill_halo_regions!(PAR.field, model.clock, fields(model))
 
     return nothing
@@ -177,6 +163,5 @@ adapt_structure(to, par::TwoBandPhotosyntheticallyActiveRadiation) =
                                              adapt(to, par.chlorophyll_red_exponent),
                                              adapt(to, par.chlorophyll_blue_exponent),
                                              adapt(to, par.pigment_ratio),
-                                             adapt(to, par.phytoplankton_chlorophyll_ratio),
                                              adapt(to, par.field),
                                              adapt(to, par.surface_PAR))

--- a/src/Light/2band.jl
+++ b/src/Light/2band.jl
@@ -75,9 +75,6 @@ end
                                                pigment_ratio = 0.7,
                                                surface_PAR = default_surface_PAR)
 
-Total chlorophyll is obtained from `chlorophyll(model.biogeochemistry, model)`, allowing the
-biogeochemistry to define chlorophyll from one or more plankton or chlorophyll fields.
-
 Keyword Arguments
 ==================
 

--- a/src/Light/multi_band.jl
+++ b/src/Light/multi_band.jl
@@ -59,7 +59,10 @@ Keyword Arguments
 ==================
 
 - `grid`: grid for building the model on
-- `water_red_attenuation`, ..., `phytoplankton_chlorophyll_ratio`: parameter values
+- `bands`, `base_bands`, `base_water_attenuation_coefficient`, `base_chlorophyll_exponent`,
+  `base_chlorophyll_attenuation_coefficient`: wavelength bands and attenuation coefficients
+- `field_names`: names of the auxiliary PAR band fields
+- `surface_PAR_division`: fraction of surface PAR assigned to each band
 - `surface_PAR`: the photosynthetically available radiation at the surface, by default,
    assumed to have the 'continuous form' `condition(x, y t)`
 

--- a/test/test_NutrientsPlanktonDetritus.jl
+++ b/test/test_NutrientsPlanktonDetritus.jl
@@ -289,7 +289,6 @@ using OceanBioME.Models.NutrientsPlanktonDetritusModels: SingleTracerNutrient
     @test par.chlorophyll_red_exponent isa Float32
     @test par.chlorophyll_blue_exponent isa Float32
     @test par.pigment_ratio isa Float32
-    @test isnothing(par.phytoplankton_chlorophyll_ratio)
 
     # nutrients is converted
     @test lobster.underlying_biogeochemistry.nutrients.nitrogen |> ((::NitrateAmmonia{FT}) where FT) -> FT == Float32

--- a/test/test_NutrientsPlanktonDetritus.jl
+++ b/test/test_NutrientsPlanktonDetritus.jl
@@ -289,7 +289,7 @@ using OceanBioME.Models.NutrientsPlanktonDetritusModels: SingleTracerNutrient
     @test par.chlorophyll_red_exponent isa Float32
     @test par.chlorophyll_blue_exponent isa Float32
     @test par.pigment_ratio isa Float32
-    @test par.phytoplankton_chlorophyll_ratio isa Float32
+    @test isnothing(par.phytoplankton_chlorophyll_ratio)
 
     # nutrients is converted
     @test lobster.underlying_biogeochemistry.nutrients.nitrogen |> ((::NitrateAmmonia{FT}) where FT) -> FT == Float32

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -2,37 +2,20 @@ include("dependencies_for_runtests.jl")
 
 using CUDA: @allowscalar
 
-using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation, 
-                  PrescribedAttenuationPAR, 
+using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation,
+                  PrescribedAttenuationPAR,
                   LOBSTER, NPZD, ImplicitBiology
 
 using Oceananigans.Architectures: on_architecture
-using Oceananigans.Biogeochemistry: AbstractBiogeochemistry,
-                                    update_biogeochemical_state!,
+using Oceananigans.Biogeochemistry: update_biogeochemical_state!,
+                                    required_biogeochemical_tracers,
                                     biogeochemical_auxiliary_fields
-
-import Oceananigans.Biogeochemistry: required_biogeochemical_tracers,
-                                     required_biogeochemical_auxiliary_fields
-
-import OceanBioME: chlorophyll
 
 Pᵢ(x,y,z) = 2.5 + z
 
-struct MultiPhytoplanktonLightTest <: AbstractBiogeochemistry end
-
-required_biogeochemical_tracers(::MultiPhytoplanktonLightTest) = (:P1, :P2, :P3)
-required_biogeochemical_auxiliary_fields(::MultiPhytoplanktonLightTest) = (:PAR, )
-
-@inline function (::MultiPhytoplanktonLightTest)(i, j, k, grid, val_name, clock, fields, auxiliary_fields)
-    return zero(fields.P1[i, j, k])
-end
-
-@inline chlorophyll(::MultiPhytoplanktonLightTest, model) =
-    model.tracers.P1 + 2 * model.tracers.P2 + 3 * model.tracers.P3
-
 function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters = nothing)
-    biogeochemistry = NPZD(grid; 
-                           light_attenuation = 
+    biogeochemistry = NPZD(grid;
+                           light_attenuation =
                                TwoBandPhotosyntheticallyActiveRadiation(grid, surface_PAR;
                                                                         discrete_form,
                                                                         parameters))
@@ -70,31 +53,10 @@ function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters 
     return nothing
 end
 
-function multi_phytoplankton_PAR(grid; P1, P2, P3, surface_PAR = 100, discrete_form = false, parameters = nothing)
-    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, surface_PAR; discrete_form, parameters)
-    biogeochemistry = Biogeochemistry(MultiPhytoplanktonLightTest(); light_attenuation)
-    model = NonhydrostaticModel(grid; biogeochemistry, buoyancy = nothing, tracers = nothing)
-
-    @test !hasproperty(model.tracers, :P)
-    set!(model; P1, P2, P3)
-
-    return Array(interior(biogeochemical_auxiliary_fields(biogeochemistry).PAR))[1, 1, :]
-end
-
-function npzd_two_band_PAR(grid)
-    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
-    biogeochemistry = NPZD(grid; light_attenuation)
-    model = NonhydrostaticModel(grid; biogeochemistry, buoyancy = nothing, tracers = nothing)
-
-    set!(model, P = Pᵢ)
-
-    return Array(interior(biogeochemical_auxiliary_fields(biogeochemistry).PAR))[1, 1, :]
-end
-
-function test_prescribed_attenuation(grid, model_type, 
-                                     surface_PAR, surface_discrete_form, 
-                                     attenuation, attenuation_discrete_form, 
-                                     surface_parameters = nothing, 
+function test_prescribed_attenuation(grid, model_type,
+                                     surface_PAR, surface_discrete_form,
+                                     attenuation, attenuation_discrete_form,
+                                     surface_parameters = nothing,
                                      attenuation_parameters = nothing)
 
     light_attenuation = PrescribedAttenuationPAR(grid, surface_PAR;
@@ -103,7 +65,7 @@ function test_prescribed_attenuation(grid, model_type,
                                                  attenuation,
                                                  attenuation_discrete_form,
                                                  attenuation_parameters)
-                                                 
+
     biogeochemistry = ImplicitBiology(grid; light_attenuation)
 
     model = model_type(grid;
@@ -211,30 +173,10 @@ field_surface_PAR = Oceananigans.Fields.ConstantField(100)
     test_prescribed_attenuation(grid, NonhydrostaticModel, continuous_surface_PAR, false, (args...) -> 0.1, true, 100) # discrete attenuation
 end
 
-@testset "TwoBand generic phytoplankton chlorophyll" begin
-    grid = RectilinearGrid(architecture; size = (1, 1, 3), extent = (1, 1, 3))
-
-    PAR_P1 = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0, P3 = 0)
-    PAR_P2 = multi_phytoplankton_PAR(grid; P1 = 0, P2 = 0.5, P3 = 0)
-    PAR_P3 = multi_phytoplankton_PAR(grid; P1 = 0, P2 = 0, P3 = 1/3)
-    PAR_split = multi_phytoplankton_PAR(grid; P1 = 0.2, P2 = 0.1, P3 = 0.2)
-    PAR_more = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0.5, P3 = 0)
-    PAR_discrete = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0, P3 = 0,
-                                           surface_PAR = discrete_surface_PAR, discrete_form = true)
-    PAR_continuous = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0, P3 = 0,
-                                             surface_PAR = continuous_surface_PAR, parameters = 100)
-
-    @test PAR_P1 ≈ PAR_P2
-    @test PAR_P1 ≈ PAR_P3
-    @test PAR_P1 ≈ PAR_split
-    @test PAR_P1 ≈ PAR_discrete
-    @test PAR_P1 ≈ PAR_continuous
-    @test all(PAR_more .< PAR_P1)
-end
-
 @testset "Float32 TwoBandPhotosyntheticallyActiveRadiation" begin
-    grid = RectilinearGrid(architecture, Float32; size = (3, 3, 10), extent = (10, 10, 200))
+    grid = RectilinearGrid(architecture, Float32; size=(3, 3, 10), extent=(10, 10, 200))
     par = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
+
     @test par.water_red_attenuation isa Float32
     @test par.water_blue_attenuation isa Float32
     @test par.chlorophyll_red_attenuation isa Float32
@@ -242,10 +184,4 @@ end
     @test par.chlorophyll_red_exponent isa Float32
     @test par.chlorophyll_blue_exponent isa Float32
     @test par.pigment_ratio isa Float32
-
-    generic_PAR = multi_phytoplankton_PAR(grid; P1 = 1f0, P2 = 0.5f0, P3 = 0.25f0)
-    npzd_PAR = npzd_two_band_PAR(grid)
-
-    @test eltype(generic_PAR) == Float32
-    @test eltype(npzd_PAR) == Float32
 end

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -7,11 +7,27 @@ using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation,
                   LOBSTER, NPZD, ImplicitBiology
 
 using Oceananigans.Architectures: on_architecture
-using Oceananigans.Biogeochemistry: update_biogeochemical_state!, 
+using Oceananigans.Biogeochemistry: AbstractBiogeochemistry,
+                                    update_biogeochemical_state!, 
                                     required_biogeochemical_tracers, 
+                                    required_biogeochemical_auxiliary_fields,
                                     biogeochemical_auxiliary_fields
 
+import OceanBioME: chlorophyll
+
 Pᵢ(x,y,z) = 2.5 + z
+
+struct MultiPhytoplanktonLightTest <: AbstractBiogeochemistry end
+
+required_biogeochemical_tracers(::MultiPhytoplanktonLightTest) = (:P1, :P2, :P3)
+required_biogeochemical_auxiliary_fields(::MultiPhytoplanktonLightTest) = (:PAR, )
+
+@inline function (::MultiPhytoplanktonLightTest)(i, j, k, grid, val_name, clock, fields, auxiliary_fields)
+    return zero(fields.P1[i, j, k])
+end
+
+@inline chlorophyll(::MultiPhytoplanktonLightTest, model) =
+    model.tracers.P1 + 2 * model.tracers.P2 + 3 * model.tracers.P3
 
 function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters = nothing)
     biogeochemistry = NPZD(grid; 
@@ -51,6 +67,17 @@ function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters 
     @test all(results_PAR .≈ reverse(expected_PAR))
 
     return nothing
+end
+
+function multi_phytoplankton_PAR(grid; P1, P2, P3)
+    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
+    biogeochemistry = Biogeochemistry(MultiPhytoplanktonLightTest(); light_attenuation)
+    model = NonhydrostaticModel(grid; biogeochemistry, buoyancy = nothing, tracers = nothing)
+
+    @test !hasproperty(model.tracers, :P)
+    set!(model; P1, P2, P3)
+
+    return Array(interior(biogeochemical_auxiliary_fields(biogeochemistry).PAR))[1, 1, :]
 end
 
 function test_prescribed_attenuation(grid, model_type, 
@@ -171,6 +198,21 @@ field_surface_PAR = Oceananigans.Fields.ConstantField(100)
 
     test_prescribed_attenuation(grid, NonhydrostaticModel, continuous_surface_PAR, false, (x, y, z, t, a0) -> a0, false, 100, 0.1) # continuous attenuation with parameters
     test_prescribed_attenuation(grid, NonhydrostaticModel, continuous_surface_PAR, false, (args...) -> 0.1, true, 100) # discrete attenuation
+end
+
+@testset "TwoBand generic phytoplankton chlorophyll" begin
+    grid = RectilinearGrid(architecture; size = (1, 1, 3), extent = (1, 1, 3))
+
+    PAR_P1 = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0, P3 = 0)
+    PAR_P2 = multi_phytoplankton_PAR(grid; P1 = 0, P2 = 0.5, P3 = 0)
+    PAR_P3 = multi_phytoplankton_PAR(grid; P1 = 0, P2 = 0, P3 = 1/3)
+    PAR_split = multi_phytoplankton_PAR(grid; P1 = 0.2, P2 = 0.1, P3 = 0.2)
+    PAR_more = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0.5, P3 = 0)
+
+    @test PAR_P1 ≈ PAR_P2
+    @test PAR_P1 ≈ PAR_P3
+    @test PAR_P1 ≈ PAR_split
+    @test all(PAR_more .< PAR_P1)
 end
 
 @testset "Float32 TwoBandPhotosyntheticallyActiveRadiation" begin

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -2,20 +2,20 @@ include("dependencies_for_runtests.jl")
 
 using CUDA: @allowscalar
 
-using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation,
-                  PrescribedAttenuationPAR,
+using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation, 
+                  PrescribedAttenuationPAR, 
                   LOBSTER, NPZD, ImplicitBiology
 
 using Oceananigans.Architectures: on_architecture
-using Oceananigans.Biogeochemistry: update_biogeochemical_state!,
-                                    required_biogeochemical_tracers,
+using Oceananigans.Biogeochemistry: update_biogeochemical_state!, 
+                                    required_biogeochemical_tracers, 
                                     biogeochemical_auxiliary_fields
 
 Pᵢ(x,y,z) = 2.5 + z
 
 function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters = nothing)
-    biogeochemistry = NPZD(grid;
-                           light_attenuation =
+    biogeochemistry = NPZD(grid; 
+                           light_attenuation = 
                                TwoBandPhotosyntheticallyActiveRadiation(grid, surface_PAR;
                                                                         discrete_form,
                                                                         parameters))
@@ -53,10 +53,10 @@ function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters 
     return nothing
 end
 
-function test_prescribed_attenuation(grid, model_type,
-                                     surface_PAR, surface_discrete_form,
-                                     attenuation, attenuation_discrete_form,
-                                     surface_parameters = nothing,
+function test_prescribed_attenuation(grid, model_type, 
+                                     surface_PAR, surface_discrete_form, 
+                                     attenuation, attenuation_discrete_form, 
+                                     surface_parameters = nothing, 
                                      attenuation_parameters = nothing)
 
     light_attenuation = PrescribedAttenuationPAR(grid, surface_PAR;
@@ -65,7 +65,7 @@ function test_prescribed_attenuation(grid, model_type,
                                                  attenuation,
                                                  attenuation_discrete_form,
                                                  attenuation_parameters)
-
+                                                 
     biogeochemistry = ImplicitBiology(grid; light_attenuation)
 
     model = model_type(grid;

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -8,10 +8,11 @@ using OceanBioME: TwoBandPhotosyntheticallyActiveRadiation,
 
 using Oceananigans.Architectures: on_architecture
 using Oceananigans.Biogeochemistry: AbstractBiogeochemistry,
-                                    update_biogeochemical_state!, 
-                                    required_biogeochemical_tracers, 
-                                    required_biogeochemical_auxiliary_fields,
+                                    update_biogeochemical_state!,
                                     biogeochemical_auxiliary_fields
+
+import Oceananigans.Biogeochemistry: required_biogeochemical_tracers,
+                                     required_biogeochemical_auxiliary_fields
 
 import OceanBioME: chlorophyll
 

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -69,13 +69,23 @@ function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters 
     return nothing
 end
 
-function multi_phytoplankton_PAR(grid; P1, P2, P3)
-    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
+function multi_phytoplankton_PAR(grid; P1, P2, P3, surface_PAR = 100, discrete_form = false, parameters = nothing)
+    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, surface_PAR; discrete_form, parameters)
     biogeochemistry = Biogeochemistry(MultiPhytoplanktonLightTest(); light_attenuation)
     model = NonhydrostaticModel(grid; biogeochemistry, buoyancy = nothing, tracers = nothing)
 
     @test !hasproperty(model.tracers, :P)
     set!(model; P1, P2, P3)
+
+    return Array(interior(biogeochemical_auxiliary_fields(biogeochemistry).PAR))[1, 1, :]
+end
+
+function npzd_two_band_PAR(grid; phytoplankton_chlorophyll_ratio = nothing)
+    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, 100; phytoplankton_chlorophyll_ratio)
+    biogeochemistry = NPZD(grid; light_attenuation)
+    model = NonhydrostaticModel(grid; biogeochemistry, buoyancy = nothing, tracers = nothing)
+
+    set!(model, P = Pᵢ)
 
     return Array(interior(biogeochemical_auxiliary_fields(biogeochemistry).PAR))[1, 1, :]
 end
@@ -208,16 +218,32 @@ end
     PAR_P3 = multi_phytoplankton_PAR(grid; P1 = 0, P2 = 0, P3 = 1/3)
     PAR_split = multi_phytoplankton_PAR(grid; P1 = 0.2, P2 = 0.1, P3 = 0.2)
     PAR_more = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0.5, P3 = 0)
+    PAR_discrete = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0, P3 = 0,
+                                           surface_PAR = discrete_surface_PAR, discrete_form = true)
+    PAR_continuous = multi_phytoplankton_PAR(grid; P1 = 1, P2 = 0, P3 = 0,
+                                             surface_PAR = continuous_surface_PAR, parameters = 100)
 
     @test PAR_P1 ≈ PAR_P2
     @test PAR_P1 ≈ PAR_P3
     @test PAR_P1 ≈ PAR_split
+    @test PAR_P1 ≈ PAR_discrete
+    @test PAR_P1 ≈ PAR_continuous
     @test all(PAR_more .< PAR_P1)
 end
 
+@testset "TwoBand legacy chlorophyll ratio compatibility" begin
+    grid = RectilinearGrid(architecture; size = (1, 1, 3), extent = (1, 1, 3))
+
+    generic_PAR = npzd_two_band_PAR(grid)
+    legacy_PAR = npzd_two_band_PAR(grid; phytoplankton_chlorophyll_ratio = 1.31)
+
+    @test generic_PAR ≈ legacy_PAR
+end
+
 @testset "Float32 TwoBandPhotosyntheticallyActiveRadiation" begin
-    grid = RectilinearGrid(architecture, Float32; size=(3, 3, 10), extent=(10, 10, 200))
+    grid = RectilinearGrid(architecture, Float32; size = (3, 3, 10), extent = (10, 10, 200))
     par = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
+    legacy_par = TwoBandPhotosyntheticallyActiveRadiation(grid, 100; phytoplankton_chlorophyll_ratio = 1.31)
 
     @test par.water_red_attenuation isa Float32
     @test par.water_blue_attenuation isa Float32
@@ -227,4 +253,11 @@ end
     @test par.chlorophyll_blue_exponent isa Float32
     @test par.pigment_ratio isa Float32
     @test isnothing(par.phytoplankton_chlorophyll_ratio)
+    @test legacy_par.phytoplankton_chlorophyll_ratio isa Float32
+
+    generic_PAR = multi_phytoplankton_PAR(grid; P1 = 1f0, P2 = 0.5f0, P3 = 0.25f0)
+    legacy_PAR = npzd_two_band_PAR(grid; phytoplankton_chlorophyll_ratio = 1.31f0)
+
+    @test eltype(generic_PAR) == Float32
+    @test eltype(legacy_PAR) == Float32
 end

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -80,8 +80,8 @@ function multi_phytoplankton_PAR(grid; P1, P2, P3, surface_PAR = 100, discrete_f
     return Array(interior(biogeochemical_auxiliary_fields(biogeochemistry).PAR))[1, 1, :]
 end
 
-function npzd_two_band_PAR(grid; phytoplankton_chlorophyll_ratio = nothing)
-    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, 100; phytoplankton_chlorophyll_ratio)
+function npzd_two_band_PAR(grid)
+    light_attenuation = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
     biogeochemistry = NPZD(grid; light_attenuation)
     model = NonhydrostaticModel(grid; biogeochemistry, buoyancy = nothing, tracers = nothing)
 
@@ -231,20 +231,9 @@ end
     @test all(PAR_more .< PAR_P1)
 end
 
-@testset "TwoBand legacy chlorophyll ratio compatibility" begin
-    grid = RectilinearGrid(architecture; size = (1, 1, 3), extent = (1, 1, 3))
-
-    generic_PAR = npzd_two_band_PAR(grid)
-    legacy_PAR = npzd_two_band_PAR(grid; phytoplankton_chlorophyll_ratio = 1.31)
-
-    @test generic_PAR ≈ legacy_PAR
-end
-
 @testset "Float32 TwoBandPhotosyntheticallyActiveRadiation" begin
     grid = RectilinearGrid(architecture, Float32; size = (3, 3, 10), extent = (10, 10, 200))
     par = TwoBandPhotosyntheticallyActiveRadiation(grid, 100)
-    legacy_par = TwoBandPhotosyntheticallyActiveRadiation(grid, 100; phytoplankton_chlorophyll_ratio = 1.31)
-
     @test par.water_red_attenuation isa Float32
     @test par.water_blue_attenuation isa Float32
     @test par.chlorophyll_red_attenuation isa Float32
@@ -252,12 +241,10 @@ end
     @test par.chlorophyll_red_exponent isa Float32
     @test par.chlorophyll_blue_exponent isa Float32
     @test par.pigment_ratio isa Float32
-    @test isnothing(par.phytoplankton_chlorophyll_ratio)
-    @test legacy_par.phytoplankton_chlorophyll_ratio isa Float32
 
     generic_PAR = multi_phytoplankton_PAR(grid; P1 = 1f0, P2 = 0.5f0, P3 = 0.25f0)
-    legacy_PAR = npzd_two_band_PAR(grid; phytoplankton_chlorophyll_ratio = 1.31f0)
+    npzd_PAR = npzd_two_band_PAR(grid)
 
     @test eltype(generic_PAR) == Float32
-    @test eltype(legacy_PAR) == Float32
+    @test eltype(npzd_PAR) == Float32
 end

--- a/test/test_light.jl
+++ b/test/test_light.jl
@@ -35,7 +35,7 @@ function test_two_band(grid, model_type, surface_PAR, discrete_form, parameters 
     eʳ = PAR_model.chlorophyll_red_exponent
     eᵇ = PAR_model.chlorophyll_blue_exponent
     r = PAR_model.pigment_ratio
-    Rᶜₚ = PAR_model.phytoplankton_chlorophyll_ratio
+    Rᶜₚ = biogeochemistry.underlying_biogeochemistry.plankton.chlorophyll_ratio
 
     ∫Chlʳ = [(2.0 * Rᶜₚ / r) ^ eʳ * 0.5]
     ∫Chlᵇ = [(2.0 * Rᶜₚ / r) ^ eᵇ * 0.5]
@@ -184,5 +184,5 @@ end
     @test par.chlorophyll_red_exponent isa Float32
     @test par.chlorophyll_blue_exponent isa Float32
     @test par.pigment_ratio isa Float32
-    @test par.phytoplankton_chlorophyll_ratio isa Float32
+    @test isnothing(par.phytoplankton_chlorophyll_ratio)
 end


### PR DESCRIPTION
Generalizes `TwoBandPhotosyntheticallyActiveRadiation` so that chlorophyll attenuation is obtained from the biogeochemistry through the existing `chlorophyll(...)` interface rather than assuming a single phytoplankton tracer named `P`.

Previously, TwoBand calculated chlorophyll internally as a fixed chlorophyll-to-phytoplankton ratio multiplied by `model.tracers.P`. This tied the light model to biogeochemical models with exactly one phytoplankton tracer using that name.

With this change, TwoBand instead uses:

```julia
chlorophyll(model.biogeochemistry, model)
```

This makes the light model independent of the number, names, and representation of phytoplankton tracers.

Standard NutrientsPlanktonDetritus/LOBSTER behaviour should remain unchanged, since PhytoZoo already defines:

```julia
chlorophyll(plankton::PhytoZoo, model) =
    plankton.chlorophyll_ratio * model.tracers.P
```

The change does remove the separate `phytoplankton_chlorophyll_ratio` option from `TwoBandPhotosyntheticallyActiveRadiation`. This previously allowed TwoBand itself to convert P directly to chlorophyll. However, this appears to be redundant with the current chlorophyll(...) interface since NPD/LOBSTER now owns its chlorophyll ratio through PhytoZoo, while PISCES provides chlorophyll from it's own state representation. Nonetheless, worth checking if dropping this causes any issue? 

related to https://github.com/orgs/OceanBioME/discussions/390 